### PR TITLE
Preparation for 1.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ venv
 *.csv
 __pycache__
 .env
+.env.dev
 .venv
 team.db
 Cocktail_database.db

--- a/docs/devnotes.md
+++ b/docs/devnotes.md
@@ -54,14 +54,17 @@ yourbutton.clicked.connect(some_function)
 
 Here are some todos, for now or later versions:
 
-- [x] Add validation of countrycode and only use supported codes
-  - [x] add supported codes paramter as a list to the src.init file
-- [x] Add new config parameter for machine name
-  - [x] Using `CocktailBerry (#RandomLongNumber)` as default (uuid?)
-  - [x] Add validation of the length for the name, limit it by reasonable length (something like 30 chars?)
+- [ ] Extent RPi Controller API to be more generic for also other boards
+  - [ ] Introduce new config var to set board type
+  - [ ] Add list of supported board types to settings
+  - [ ] Check if setting is in list of supported types
+  - [ ] Refactor RPi to machine controller
+  - [ ] New board / pin controlller class for machine controller to inherit pin methods from
 - [ ] Review microservice and its features
   - [ ] Email always is quite tricky, maybe get something more "working", or just remove it
   - [x] Review que logic for failed sending
   - [x] Add aditional logic for the new official endpoint + api key .env variable slot for example file
   - [x] Extend API for receiving as well as sending of language used and machine name
-  - [x] Generally review this logic, maybe extend it to make it work with other custom endpoints using keys are other header auth features
+  - [ ] Generally review this logic, maybe extend it to make it work with other custom endpoints using keys are other header auth features
+    - [ ] Make it to work with any amount of urls / header things
+    - [x] Make it work with the official API

--- a/docs/devnotes.md
+++ b/docs/devnotes.md
@@ -54,14 +54,14 @@ yourbutton.clicked.connect(some_function)
 
 Here are some todos, for now or later versions:
 
-- Add validation of countrycode and only use supported codes
-  - add supported codes paramter as a list to the src.init file
-- Add new config parameter for machine name
-  - Using `CocktailBerry (#RandomLongNumber)` as default (uuid?)
-  - Add validation of the length for the name, limit it by reasonable length (something like 30-50 chars?)
-- Review microservice and its features
-  - Email always is quite tricky, maybe get something more "working", or just remove it
-  - Review que logic for failed sending
-  - Add aditional logic for the new official endpoint + api key .env variable slot for example file
-  - Extend API for receiving as well as sending of language used and machine name
-  - Generally review this logic, maybe extend it to make it work with other custom endpoints using keys are other header auth features
+- [x] Add validation of countrycode and only use supported codes
+  - [x] add supported codes paramter as a list to the src.init file
+- [x] Add new config parameter for machine name
+  - [x] Using `CocktailBerry (#RandomLongNumber)` as default (uuid?)
+  - [x] Add validation of the length for the name, limit it by reasonable length (something like 30 chars?)
+- [ ] Review microservice and its features
+  - [ ] Email always is quite tricky, maybe get something more "working", or just remove it
+  - [x] Review que logic for failed sending
+  - [x] Add aditional logic for the new official endpoint + api key .env variable slot for example file
+  - [x] Extend API for receiving as well as sending of language used and machine name
+  - [x] Generally review this logic, maybe extend it to make it work with other custom endpoints using keys are other header auth features

--- a/docs/devnotes.md
+++ b/docs/devnotes.md
@@ -8,6 +8,7 @@ This is an additional section for information, generally not relevant for the us
 - [Program Schema](#program-schema)
 - [PyQt](#pyqt)
   - [Button clicked.connect behaviour](#button-clickedconnect-behaviour)
+- [ToDos](#todos)
 
 
 # Python Version
@@ -47,3 +48,20 @@ yourbutton.clicked.connect(lambda: some_function())
 # and will call some_function(False)
 yourbutton.clicked.connect(some_function)
 ```
+
+
+# ToDos
+
+Here are some todos, for now or later versions:
+
+- Add validation of countrycode and only use supported codes
+  - add supported codes paramter as a list to the src.init file
+- Add new config parameter for machine name
+  - Using `CocktailBerry (#RandomLongNumber)` as default (uuid?)
+  - Add validation of the length for the name, limit it by reasonable length (something like 30-50 chars?)
+- Review microservice and its features
+  - Email always is quite tricky, maybe get something more "working", or just remove it
+  - Review que logic for failed sending
+  - Add aditional logic for the new official endpoint + api key .env variable slot for example file
+  - Extend API for receiving as well as sending of language used and machine name
+  - Generally review this logic, maybe extend it to make it work with other custom endpoints using keys are other header auth features

--- a/microservice/.env.example
+++ b/microservice/.env.example
@@ -2,3 +2,4 @@ HOOK_ENDPOINT=enpointforhook
 SENDER_ADDRESS=cocktaimachine_adress
 SENDER_PASSWORD=cocktailmachine_password
 RECEIVER_ADRESS=receiver_adress
+API_KEY=readdocshowtoget

--- a/microservice/app.py
+++ b/microservice/app.py
@@ -31,6 +31,8 @@ def post_cocktail_hook():
         try:
             req = requests.post(url, data=payload, headers=headers)
             app.logger.info(f"{req.status_code}: Posted to {url} with payload: {payload}")
+            # Check if there is still querries data which was not send previously
+            try_send_querry_data(app)
         except requests.exceptions.ConnectionError:
             app.logger.error(f"Could not connect to {url} for the cocktail data!")
             db_handler = DatabaseHandler()

--- a/microservice/app.py
+++ b/microservice/app.py
@@ -12,6 +12,7 @@ from flask import Flask, request, abort, jsonify
 from querry_sender import try_send_querry_data
 from email_sender import send_mail
 from database import DatabaseHandler
+from helper import generate_headers_and_urls
 
 load_dotenv()
 
@@ -29,11 +30,14 @@ def post_cocktail_hook():
     def post_to_hook(url: str, payload: str, headers: Dict):
         try:
             req = requests.post(url, data=payload, headers=headers)
-            app.logger.info(f"{req.status_code}: Posted to webhook with payload: {payload}")
+            app.logger.info(f"{req.status_code}: Posted to {url} with payload: {payload}")
         except requests.exceptions.ConnectionError:
-            app.logger.error("Could not connect to the webhook for the cocktail!")
+            app.logger.error(f"Could not connect to {url} for the cocktail data!")
             db_handler = DatabaseHandler()
-            db_handler.save_failed_post(payload)
+            db_handler.save_failed_post(payload, url)
+        # pylint: disable=broad-except
+        except Exception as err:
+            app.logger.error(f"Some other error occured: {err}")
 
     if not request.json or not "cocktailname" in request.json:
         abort(400)
@@ -44,12 +48,12 @@ def post_cocktail_hook():
         "countrycode": request.json["countrycode"],
         "makedate": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M"),
     }
-    url = os.getenv("HOOK_ENDPOINT")
-    headers = {"content-type": "application/json"}
+    headers, urls = generate_headers_and_urls()
     payload = json.dumps(cocktail)
 
-    thread = Thread(target=post_to_hook, args=(url, payload, headers,))
-    thread.start()
+    for url in urls:
+        thread = Thread(target=post_to_hook, args=(url, payload, headers,))
+        thread.start()
     return jsonify({"text": "Post to cocktail webhook started"}), 201
 
 

--- a/microservice/app.py
+++ b/microservice/app.py
@@ -40,6 +40,8 @@ def post_cocktail_hook():
     cocktail = {
         "cocktailname": request.json["cocktailname"],
         "volume": request.json["volume"],
+        "machinename": request.json["machinename"],
+        "countrycode": request.json["countrycode"],
         "makedate": datetime.datetime.now().strftime("%d/%m/%Y, %H:%M"),
     }
     url = os.getenv("HOOK_ENDPOINT")

--- a/microservice/helper.py
+++ b/microservice/helper.py
@@ -1,0 +1,21 @@
+import os
+from typing import Dict, List, Tuple
+
+DEFAULT_HOOK_EP = "enpointforhook"
+DEFAULT_API_KEY = "readdocshowtoget"
+API_ENDPOINT = "https://cberry.deta.dev/cocktail"
+
+
+def generate_headers_and_urls() -> Tuple[Dict, List[str]]:
+    """Generates the header as well as the urls from the .env data"""
+    hookurl = os.getenv("HOOK_ENDPOINT")
+    api_key = os.getenv("API_KEY")
+    headers = {
+        "content-type": "application/json",
+        "X-API-Key": api_key,
+    }
+    use_hook = hookurl != DEFAULT_HOOK_EP
+    use_api = api_key != DEFAULT_API_KEY
+    urls = ([hookurl] if use_hook else []) + ([API_ENDPOINT] if use_api else [])
+
+    return headers, urls

--- a/microservice/querry_sender.py
+++ b/microservice/querry_sender.py
@@ -1,24 +1,28 @@
-import os
 import requests
 from flask import Flask
 from database import DatabaseHandler
+from helper import generate_headers_and_urls
 
 
 def try_send_querry_data(app: Flask):
     db_handler = DatabaseHandler()
     failed_data = db_handler.get_failed_data()
-    headers = {"content-type": "application/json"}
-    url = os.getenv("HOOK_ENDPOINT")
+    headers, _ = generate_headers_and_urls()
     # Return if nothing to do
     if not failed_data:
         return
     # Else try to send all remaining data
     app.logger.info("Found some not sended data, trying to send ...")
-    for send_id, data in failed_data:
+    for send_id, data, url in failed_data:
         try:
             res = requests.post(url, data=data, headers=headers)
-            app.logger.info(f"Code: {res.status_code}, Payload: {data}")
+            app.logger.info(f"Code: {res.status_code}, to: {url}, Payload: {data}")
         except requests.exceptions.ConnectionError:
+            app.logger.error("There is still no connection")
+            return
+        # pylint: disable=broad-except
+        except Exception as err:
+            app.logger.error(f"Some other error occured: {err}")
             return
         # if send successfully, delete this entry
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "CocktailBerry"
-version = "1.6.1"
+version = "1.7.0"
 description = "A Python and Qt based App for a Cocktail Machine on a Raspberry Pi. Easily serve Cocktails with Raspberry Pi and Python"
 authors = ["Andre Wohnsland <Andre_Wohnsland@web.de>"]
 readme = "readme.md"

--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,7 @@ Supercharge your next party to a whole new level! 🐍 + 🍸 = 🥳
 - [Advanced Topics](#advanced-topics)
   - [Usage of Services](#usage-of-services)
   - [Microservices](#microservices)
+    - [Posting Data to the Official API](#posting-data-to-the-official-api)
   - [Dashboard with Teams](#dashboard-with-teams)
   - [Installing Docker](#installing-docker)
 - [Troubleshooting](#troubleshooting)
@@ -239,7 +240,8 @@ These values are stored under the `custom_config.yaml` file. This file will be c
 | `UI_HEIGHT`             |    _int_    | Desired interface height, default is 480                                      |    ❌     |
 | `PUMP_PINS`             | _list[int]_ | List of the RPi-Pins where each Pump is connected                             |    ❌     |
 | `PUMP_VOLUMEFLOW`       | _list[int]_ | List of the according volume flow for each pump in ml/s                       |    ❌     |
-| `MAKER_NUMBER_BOTTLES`  |    _int_    | Number of displayed bottles. Can use up to 16 bottles                         |    ❌     |
+| `MAKER_NAME`            |    _str_    | Give your Cocktailberry a own name, max 30 chars                              |    ❌     |
+| `MAKER_NUMBER_BOTTLES`  |    _int_    | Number of displayed bottles, can use up to 16 bottles                         |    ❌     |
 | `MAKER_SEARCH_UPDATES`  |   _bool_    | Boolean flag to search for updates at program start                           |    ❌     |
 | `MAKER_CLEAN_TIME`      |    _int_    | Time the machine will execute the cleaning program                            |    ❌     |
 | `MAKER_SLEEP_TIME`      |   _float_   | Interval between each UI refresh while generating a cocktail                  |    ❌     |
@@ -332,13 +334,18 @@ This will handle the setup of all docker services. You will have to copy the `.e
 
 ## Microservices
 
-As a further addition since __version 1.1.0__, there is the option to run a microservice within docker which handles some networking topics.
+As a further addition since __version 1.1.0__, there is the option to run a microservice within docker which handles some networking topics. Cocktail data currently includes cocktail name, produced volume, current time, used language in config and your machines name.
 Currently, this is limited to:
 
-- Posting the cocktail name, used volume and current time to a given webhook
+- Posting the cocktail data time to a given webhook
+- Posting the cocktail data to the official dashboard API (__v1.7.0__), see [detailed description](#posting-data-to-the-official-api)
 - Posting the export CSV as email to a receiver
 
 The separation was made here that a service class within CocktailBerry needs only to make a request to the microservice endpoint. Therefore, all logic is separated to the service, and there is no need for multiple worker to not block the thread when the webhook endpoint is not up (Which would result in a delay of the display without multithreading). In the future, new services can be added easily to the docker container to execute different tasks. One example of the usage [can be found in my blog](https://andrewohnsland.github.io/blog/cocktail-maker-now-with-home-assistant). The service will also temporary store the data within a database, if there was no connection to the endpoint, and try later again. This way, no data will get lost in the void.
+
+### Posting Data to the Official API
+
+When the microservice is active, you can use it not to only to send data to your own webhook, but also to the official [CocktailBerry data API](https://github.com/AndreWohnsland/CocktailBerry-WebApp) to submit your data. It will then appear on the [official dashboard](https://share.streamlit.io/andrewohnsland/cocktailberry-webapp/main/frontend/main.py). Don't worry, no private data is included, only some production data. A detailed write down [can be found on the dashboard site](https://share.streamlit.io/andrewohnsland/cocktailberry-webapp/main/frontend/main.py#how-to-participate) how you will receive your API key. You need to change the default `API_KEY` value in the `microservive/.env` file to the one you received after the submission. After that, your CocktailBerry will be able to also submit data and help populate the dashboard.
 
 ## Dashboard with Teams
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,4 @@
 __version__ = "1.6.1"
 PROJECT_NAME = "CocktailBerry"
 MAX_SUPPORTED_BOTTLES = 16
+SUPPORTED_LANGUAGES = ["en", "de"]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.6.1"
+__version__ = "1.7.0"
 PROJECT_NAME = "CocktailBerry"
 MAX_SUPPORTED_BOTTLES = 16
 SUPPORTED_LANGUAGES = ["en", "de"]

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -110,6 +110,8 @@ class ConfigManager:
         if config_setting is None:
             return
         datatype, check_functions = config_setting
+        # check first if type fits, if list, also check listelements.
+        # Additionally run all check funktions provided
         if isinstance(configvalue, datatype):
             if isinstance(configvalue, list):
                 self.__validate_config_list_type(configname, configvalue)

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -93,8 +93,8 @@ class ConfigManager:
             "UI_LANGUAGE": (str, [self.__validate_language_code]),
             "UI_WIDTH": (int, []),
             "UI_HEIGHT": (int, []),
-            "PUMP_PINS": (list, []),
-            "PUMP_VOLUMEFLOW": (list, []),
+            "PUMP_PINS": (list, [self.__validate_config_list_type]),
+            "PUMP_VOLUMEFLOW": (list, [self.__validate_config_list_type]),
             "MAKER_NAME": (str, [self.__validate_max_length]),
             "MAKER_NUMBER_BOTTLES": (int, []),
             "MAKER_CLEAN_TIME": (int, []),
@@ -103,7 +103,7 @@ class ConfigManager:
             "MICROSERVICE_ACTIVE": (bool, []),
             "MICROSERVICE_BASE_URL": (str, []),
             "TEAMS_ACTIVE": (bool, []),
-            "TEAM_BUTTON_NAMES": (list, []),
+            "TEAM_BUTTON_NAMES": (list, [self.__validate_config_list_type]),
             "TEAM_API_URL": (str, []),
         }
         config_setting = config_type.get(configname)
@@ -113,8 +113,6 @@ class ConfigManager:
         # check first if type fits, if list, also check listelements.
         # Additionally run all check funktions provided
         if isinstance(configvalue, datatype):
-            if isinstance(configvalue, list):
-                self.__validate_config_list_type(configname, configvalue)
             for check_fun in check_functions:
                 check_fun(configname, configvalue)
             return

--- a/src/service_handler.py
+++ b/src/service_handler.py
@@ -27,7 +27,13 @@ class ServiceHandler(ConfigManager):
         if not self.MICROSERVICE_ACTIVE:
             return service_disabled()
         # calculate volume in litre
-        payload = json.dumps({"cocktailname": cocktailname, "volume": cocktail_volume / 1000})
+        data = {
+            "cocktailname": cocktailname,
+            "volume": cocktail_volume,
+            "machinename": self.MAKER_NAME,
+            "countrycode": self.UI_LANGUAGE,
+        }
+        payload = json.dumps(data)
         endpoint = f"{self.base_url}/hookhandler/cocktail"
         return self.__try_to_send(endpoint, Posttype.COCKTAIL, payload=payload)
 


### PR DESCRIPTION
# 1.7.0 Preparation

This PR did some rework for the microservice, and extended it
- The service now is able to also send to the official API
- New env var for API key
- Only tries to send to official API if there is a key
- Also only tries to send to hook endpoint if the user changed to an endpoint
- This means you can now activate and run the service to send to one of the points, or even none
- Better logging in case of no connection
- Saving URL now also to retry sending only to needed points
- Adjusted docs for new config and new API things
- Config manager can be given callbacks to config to check a list of user defined function for each variable
- Checking that language is in supported languages
- Added new machine config `MAKER_NAME`, default is "CocktailBerry (#xxxxxxx)" <- Random Numbers
- Checking that maker name is no more than 30 Chars
- Service Handler propagating also new values to microservice