### PR TITLE
Predefined Cocktail Amount

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,12 @@
     "Sideview"
   ],
   "cSpell.language": "en,de",
-  "ruff.args": ["--line-length=120", "--ignore=E402"]
+  "ruff.args": [
+    "--line-length=120",
+    "--ignore=E402"
+  ],
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.autopep8"
+  },
+  "python.formatting.provider": "none"
 }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -50,6 +50,7 @@ They can be used at own risk of CocktailBerry not working 100% properly.
 | `MAKER_SLEEP_TIME`           | Interval between each time check while generating a cocktail                             |
 | `MAKER_CHECK_INTERNET`       | Do a connection check at start for time adjustment window                                |
 | `MAKER_TUBE_VOLUME`          | Volume in ml to pump up when bottle is set to new                                        |
+| `MAKER_USE_RECIPE_VOLUME`    | Do not scale but use defined amounts                                                     |
 | `LED_PINS`                   | List of pins connected to LEDs for preparation                                           |
 | `LED_BRIGHTNESS`             | Brightness for the WS281x LED (1-255)                                                    |
 | `LED_COUNT`                  | Number of LEDs on the WS281x                                                             |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "CocktailBerry"
-version = "1.24.0"
+version = "1.25.0"
 description = "A Python and Qt based App for a Cocktail Machine on a Raspberry Pi. Easily serve Cocktails with Raspberry Pi and Python"
 authors = ["Andre Wohnsland <Andre_Wohnsland@web.de>"]
 readme = "readme.md"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-__version__ = "1.24.0"
+__version__ = "1.25.0"
 PROJECT_NAME = "CocktailBerry"
 MAX_SUPPORTED_BOTTLES = 24
 SupportedLanguagesType = Literal["en", "de"]

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -93,6 +93,8 @@ class ConfigManager:
     MAKER_CHECK_INTERNET: bool = True
     # Volume to pump up if a bottle gets changed
     MAKER_TUBE_VOLUME: int = 0
+    # Option to not scale the recipe volume but use always the defined one
+    MAKER_USE_RECIPE_VOLUME: bool = False
     # List of LED pins for control
     LED_PINS: list[int] = []
     # Value for LED brightness
@@ -149,6 +151,7 @@ class ConfigManager:
             "MAKER_THEME": (ThemeChoose, []),
             "MAKER_CHECK_INTERNET": (bool, []),
             "MAKER_TUBE_VOLUME": (int, [_build_number_limiter(0, 50)]),
+            "MAKER_USE_RECIPE_VOLUME": (bool, []),
             "LED_PINS": (list, []),
             "LED_BRIGHTNESS": (int, [_build_number_limiter(1, 255)]),
             "LED_COUNT": (int, [_build_number_limiter(1, 500)]),

--- a/src/dialog_handler.py
+++ b/src/dialog_handler.py
@@ -185,11 +185,13 @@ class DialogHandler():
 
     def say_cocktail_ready(self, comment: str):
         """Informs user that the cocktail is done with additional information what to add"""
-        full_comment = ""
-        if comment:
-            header_comment = self.__choose_language("cocktail_ready_add")
-            full_comment = f"\n\n{header_comment}{comment}"
-        self.__output_language_dialog("cocktail_ready", close_time=60, full_comment=full_comment)
+        # no more message if there is no additional information
+        if not comment:
+            return
+        close_time = 60
+        header_comment = self.__choose_language("cocktail_ready_add")
+        full_comment = f"\n\n{header_comment}{comment}"
+        self.__output_language_dialog("cocktail_ready", close_time=close_time, full_comment=full_comment)
 
     def say_enter_cocktail_name(self):
         """Informs user that no cocktail name was supplied"""

--- a/src/language.yaml
+++ b/src/language.yaml
@@ -531,6 +531,9 @@ ui:
     MAKER_TUBE_VOLUME:
       en: 'Empty tube volume from bottle to pump'
       de: 'Leeres Schlauchvolumen von Flasche zu Pumpe'
+    MAKER_USE_RECIPE_VOLUME:
+      en: 'Use recipe volume instead of scaling to defined volume. This disables scaling of cocktail amount in the maker tab.'
+      de: 'Verwende Rezept Volumen anstatt Skalierung auf definiertes Volumen. Dies deaktiviert die Skalierung von Cocktail Menge im Maker Tab.'
     LED_PINS:
       en: 'List of pins controlling LEDs during preparation'
       de: 'Liste an Pins, die LEDs bei der Zubereitung kontrollieren'

--- a/src/machine/controller.py
+++ b/src/machine/controller.py
@@ -132,7 +132,8 @@ class MachineController():
                 section_time = round(section_time + cfg.MAKER_SLEEP_TIME, 2)
                 time.sleep(cfg.MAKER_SLEEP_TIME)
                 if w is not None:
-                    w.change_progression_window(current_time / max_time * 100)
+                    progress = int(current_time / max_time * 100)
+                    w.change_progression_window(progress)
                 qApp.processEvents()
             _print_time(current_time, max_time)
             self._stop_pumps(pins)

--- a/src/tabs/maker.py
+++ b/src/tabs/maker.py
@@ -47,6 +47,9 @@ def update_shown_recipe(w, clear_view: bool = True):
     cocktail = DB_COMMANDER.get_cocktail(cocktail_name)
     if cocktail is None:
         return
+    # Do not scale the recipe volume if use recipe amount is activated
+    if cfg.MAKER_USE_RECIPE_VOLUME:
+        amount = cocktail.amount
     cocktail.scale_cocktail(amount, factor)
     DP_CONTROLLER.fill_recipe_data_maker(w, cocktail, amount)
 
@@ -89,6 +92,9 @@ def prepare_cocktail(w):
     cocktail = DB_COMMANDER.get_cocktail(cocktail_name)
     if cocktail is None:
         return
+    # Do not scale the recipe volume if use recipe amount is activated
+    if cfg.MAKER_USE_RECIPE_VOLUME:
+        cocktail_volume = cocktail.amount
     cocktail.scale_cocktail(cocktail_volume, alcohol_factor)
     virgin_ending = " (Virgin)" if cocktail.is_virgin else ""
     display_name = f"{cocktail_name}{virgin_ending}"
@@ -160,6 +166,9 @@ def adjust_alcohol(w, amount: float):
 
 def adjust_volume(w, amount: int):
     """changes the volume amount"""
+    # Do not scale the recipe volume if the option is activated
+    if cfg.MAKER_USE_RECIPE_VOLUME:
+        return
     new_volume = shared.cocktail_volume + amount
     shared.cocktail_volume = _limit_number(new_volume, 100, 400)
     update_shown_recipe(w, False)

--- a/src/ui/setup_mainwindow.py
+++ b/src/ui/setup_mainwindow.py
@@ -44,6 +44,7 @@ class MainScreen(QMainWindow, Ui_MainWindow):
         self.logger.log_start_program()
         self.connect_objects()
         self.connect_other_windows()
+        self.hide_necessary_elements()
         DP_CONTROLLER.initialize_window_object(self)
         # init the empty further screens
         self.numpad_window: Optional[NumpadWidget] = None
@@ -113,7 +114,7 @@ class MainScreen(QMainWindow, Ui_MainWindow):
         """ Opens up the progression window to show the Cocktail status. """
         self.progress_window = ProgressScreen(self, cocktail_type)
 
-    def change_progression_window(self, pb_value):
+    def change_progression_window(self, pb_value: int):
         """ Changes the value of the progression bar of the ProBarWindow. """
         if self.progress_window is None:
             return
@@ -171,7 +172,7 @@ class MainScreen(QMainWindow, Ui_MainWindow):
         self.LEFlaschenvolumen.clicked.connect(
             lambda: self.open_numpad(self.LEFlaschenvolumen, 50, 50, amount)
         )
-        self.LEFlaschenvolumen.setMaxLength(4)
+        self.LEFlaschenvolumen.setMaxLength(5)
         self.LECocktail.setMaxLength(30)
 
     def connect_objects(self):
@@ -243,6 +244,12 @@ class MainScreen(QMainWindow, Ui_MainWindow):
 
         for combobox in DP_CONTROLLER.get_comboboxes_bottles(self):
             combobox.activated.connect(lambda _, window=self: bottles.refresh_bottle_cb(w=window))
+
+    def hide_necessary_elements(self):
+        """Depending on the config, hide some of the unused elements"""
+        if cfg.MAKER_USE_RECIPE_VOLUME:
+            self.decrease_volume.hide()
+            self.increase_volume.hide()
 
     def handle_tab_bar_clicked(self, index):
         """Protects tabs other than maker tab with a password"""


### PR DESCRIPTION
This PR implements the option to use the cocktail recipe amounts defined in the recipe instead of the scaling method fixed by the given number in the UI. In addition, there was a bug killed which may occur when updating the progress bar, which would crash the app. The dialog window at the end of a cocktail will be only shown if there is another ingredient needed to be added via hand.