### PR TITLE
RPi5 Support

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,6 +12,15 @@ is_raspberry_pi() {
   fi
 }
 
+# check if the model is a Raspberry Pi5
+is_raspberry_pi5() {
+  if grep -q "Raspberry Pi 5" /proc/device-tree/model 2>/dev/null; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 echo "Installing updates, this may take a while..."
 sudo apt update && sudo sudo apt -y full-upgrade
 
@@ -92,6 +101,12 @@ else
   # try to install mfrc522, this will probably fail on non raspberry pi devices
   if is_raspberry_pi; then
     pip install mfrc522 rpi_ws281x || echo "ERROR: Could not install mfrc522, are you on a Raspberry Pi?"
+    # the rpi5 is a tricky thing, so we need a new gpi controller and add also the user to this group
+  fi
+  if is_raspberry_pi5; then
+    pip install gpiozero || echo "ERROR: Could not install gpiozero, are you on a Raspberry Pi5?"
+    sudo usermod -aG gpio "$(whoami)"
+    newgrp gpio
   fi
   # try to install python-periphery, so other devices may also use the gpio
   pip install python-periphery || echo "ERROR: Could not install python-periphery, if you are on a RPi, this is not needed"

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -33,7 +33,7 @@ from src.config.errors import ConfigError
 from src.config.validators import build_number_limiter, validate_max_length
 from src.filepath import CUSTOM_CONFIG_FILE
 from src.logger_handler import LoggerHandler
-from src.utils import get_platform_data
+from src.utils import get_platform_data, time_print
 
 logger = LoggerHandler("config_manager")
 
@@ -355,8 +355,8 @@ def show_start_message(machine_name: str = PROJECT_NAME):
     figlet = Figlet()
     start_message = f"{machine_name} Version {__version__}"
     print(figlet.renderText(start_message))
-    print(start_message)
-    print(get_platform_data())
+    time_print(start_message)
+    time_print(str(get_platform_data()))
 
 
 shared = Shared()

--- a/src/machine/controller.py
+++ b/src/machine/controller.py
@@ -12,7 +12,7 @@ from src.config.config_manager import shared
 from src.machine.generic_board import GenericController
 from src.machine.interface import PinController
 from src.machine.leds import LedController
-from src.machine.raspberry import RpiController
+from src.machine.raspberry import choose_pi_controller
 from src.machine.reverter import Reverter
 from src.models import Ingredient
 from src.utils import time_print
@@ -45,7 +45,7 @@ class MachineController:
     def _chose_controller(self) -> PinController:
         """Select the controller class for the Pin."""
         if cfg.MAKER_BOARD == "RPI":
-            return RpiController(cfg.MAKER_PINS_INVERTED)
+            return choose_pi_controller(cfg.MAKER_PINS_INVERTED)
         # In case none is found, fall back to generic using python-periphery
         return GenericController(cfg.MAKER_PINS_INVERTED)
 

--- a/src/machine/generic_board.py
+++ b/src/machine/generic_board.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from src.logger_handler import LoggerHandler
 from src.machine.interface import GPIOController, PinController
+from src.utils import time_print
 
 logger = LoggerHandler("GenericController")
 
@@ -31,7 +32,7 @@ class GenericController(PinController):
     def initialize_pin_list(self, pin_list: list[int], is_input: bool = False, pull_down: bool = True):
         """Set up the given pin list."""
         if not self.dev_displayed:
-            print(f"Devenvironment on the Generic Pin Control module is {'on' if self.devenvironment else 'off'}")
+            time_print(f"Devenvironment on the Generic Pin Control module is {'on' if self.devenvironment else 'off'}")
             self.dev_displayed = True
 
         # high is also output, but other default value

--- a/src/machine/raspberry.py
+++ b/src/machine/raspberry.py
@@ -1,7 +1,11 @@
-from typing import Literal, Optional
+from __future__ import annotations
+
+import contextlib
+from typing import Literal
 
 from src.logger_handler import LoggerHandler
 from src.machine.interface import GPIOController, PinController
+from src.utils import time_print
 
 logger = LoggerHandler("RpiController")
 
@@ -13,6 +17,28 @@ try:
     DEV = False
 except ModuleNotFoundError:
     DEV = True
+
+try:
+    # pylint: disable=import-error
+    from gpiozero import InputDevice, OutputDevice  # type: ignore
+
+    ZERO_DEV = False
+except ModuleNotFoundError:
+    ZERO_DEV = True
+
+
+def is_rpi5() -> bool:
+    model = "No Model"
+    with contextlib.suppress(FileNotFoundError), open("/proc/device-tree/model", encoding="utf-8") as f:
+        model = f.read()
+    return "Raspberry Pi 5" in model
+
+
+def choose_pi_controller(inverted: bool) -> PinController:
+    """Need to choose another controller for Raspberry Pi 5."""
+    if is_rpi5():
+        return Rpi5Controller(inverted)
+    return RpiController(inverted)
 
 
 class RpiController(PinController):
@@ -55,7 +81,7 @@ class RpiController(PinController):
         if not self.devenvironment:
             GPIO.output(pin_list, self.low)
 
-    def cleanup_pin_list(self, pin_list: Optional[list[int]] = None):
+    def cleanup_pin_list(self, pin_list: list[int] | None = None):
         """Clean up the given pin list, or all pins if none is given."""
         if self.devenvironment:
             return
@@ -68,6 +94,86 @@ class RpiController(PinController):
         """Return the state of the given pin."""
         if not self.devenvironment:
             return GPIO.input(pin) == GPIO.HIGH
+        return False
+
+
+class Rpi5Controller(PinController):
+    """Controller class to control Raspberry Pi pins using gpiozero."""
+
+    def __init__(self, inverted: bool) -> None:
+        super().__init__()
+        self.inverted = inverted
+        self.devenvironment = ZERO_DEV
+        self.low: bool = False
+        self.high: bool = True
+        if inverted:
+            self.low, self.high = self.high, self.low
+        self.active_high = not inverted  # Control active_high based on the inverted parameter
+        self.gpios: dict[
+            int, InputDevice | OutputDevice
+        ] = {}  # Dictionary to store GPIO pin objects (InputDevice/OutputDevice)
+        self.dev_displayed = False
+
+    def initialize_pin_list(self, pin_list: list[int], is_input: bool = False, pull_down: bool = True):
+        """Set up the given pin list using gpiozero with error handling."""
+        if not self.dev_displayed:
+            time_print(f"Devenvironment on the RPi5 module is {'on' if self.devenvironment else 'off'}")
+            self.dev_displayed = True
+
+        if self.devenvironment:
+            logger.log_event("WARNING", f"Could not import gpiozero. Will not be able to control pins: {pin_list}")
+            return
+        for pin in pin_list:
+            try:
+                if is_input:
+                    # Set pull-up/down configuration via InputDevice
+                    pull_up = not pull_down
+                    self.gpios[pin] = InputDevice(pin, pull_up=pull_up)
+                else:
+                    # Initialize OutputDevice with active_high based on the inverted flag
+                    self.gpios[pin] = OutputDevice(pin, initial_value=self.low, active_high=self.active_high)
+            except Exception as e:
+                # Catch any error and continue, printing the pin and error message
+                logger.log_event("WARNING", f"Error: Could not initialize GPIO pin {pin}. Reason: {e!s}")
+
+    def activate_pin_list(self, pin_list: list[int]):
+        """Activates the given pin list (sets to high)."""
+        if self.devenvironment:
+            return
+        for pin in pin_list:
+            if pin in self.gpios and isinstance(self.gpios[pin], OutputDevice):
+                self.gpios[pin].on()
+            else:
+                logger.log_event(
+                    "WARNING", f"Could not activate GPIO pin {pin}. Reason: Pin not activated or not an OutputDevice."
+                )
+
+    def close_pin_list(self, pin_list: list[int]):
+        """Close (deactivate) the given pin_list (sets to low)."""
+        if self.devenvironment:
+            return
+        for pin in pin_list:
+            if pin in self.gpios and isinstance(self.gpios[pin], OutputDevice):
+                self.gpios[pin].off()
+
+    def cleanup_pin_list(self, pin_list: list[int] | None = None):
+        """Clean up the given pin list, or all pins if none is given."""
+        if pin_list is None:
+            # Clean up all pins
+            for pin, device in self.gpios.items():
+                device.close()
+            self.gpios.clear()
+        else:
+            for pin in pin_list:
+                if pin in self.gpios:
+                    self.gpios[pin].close()
+                    del self.gpios[pin]
+
+    def read_pin(self, pin: int) -> bool:
+        """Return the state of the given pin (True if high, False if low)."""
+        if pin in self.gpios and isinstance(self.gpios[pin], InputDevice):
+            return self.gpios[pin].is_active  # True if high, False if low
+        logger.log_event("WARNING", f"Could not read GPIO pin {pin}. Reason: Pin not found or not an InputDevice.")
         return False
 
 

--- a/src/machine/raspberry.py
+++ b/src/machine/raspberry.py
@@ -31,7 +31,7 @@ class RpiController(PinController):
     def initialize_pin_list(self, pin_list: list[int], is_input: bool = False, pull_down: bool = True):
         """Set up the given pin list."""
         if not self.dev_displayed:
-            print(f"Devenvironment on the RPi module is {'on' if self.devenvironment else 'off'}")
+            time_print(f"Devenvironment on the RPi module is {'on' if self.devenvironment else 'off'}")
             self.dev_displayed = True
         if not self.devenvironment:
             # if it is an input, we need to set the pull up down to down or up

--- a/src/programs/addons.py
+++ b/src/programs/addons.py
@@ -11,6 +11,7 @@ from PyQt5.QtWidgets import QVBoxLayout
 from src import __version__
 from src.filepath import ADDON_FOLDER, ADDON_SKELTON
 from src.logger_handler import LoggerHandler
+from src.utils import time_print
 
 _SupportedActions = Literal["setup", "cleanup", "before_cocktail", "after_cocktail"]
 _logger = LoggerHandler("AddonManager")
@@ -63,7 +64,7 @@ class AddOnManager:
         """Execute all the setup function of the addons."""
         if self.addons:
             addon_string = ", ".join(list(self.addons.keys()))
-            print(f"Used Addons: {addon_string}")
+            time_print(f"Used Addons: {addon_string}")
         self._try_function_for_addons("setup")
         atexit.register(self.cleanup_addons)
 

--- a/src/programs/cli.py
+++ b/src/programs/cli.py
@@ -15,7 +15,7 @@ from src.programs.clearing import clear_local_database
 from src.programs.cocktailberry import run_cocktailberry
 from src.programs.data_import import importer
 from src.programs.microservice_setup import LanguageChoice, setup_service, setup_teams
-from src.utils import generate_custom_style_file, start_resource_tracker
+from src.utils import generate_custom_style_file, start_resource_tracker, time_print
 
 cli = typer.Typer(add_completion=False)
 
@@ -45,7 +45,7 @@ def main(
     cfg.sync_config_to_file()
     if debug:
         os.environ.setdefault("DEBUG_MS", "True")
-        print("Using debug mode")
+        time_print("Using debug mode")
     generate_custom_style_file()
     if calibration:
         run_calibration()

--- a/src/python_vcheck.py
+++ b/src/python_vcheck.py
@@ -2,6 +2,7 @@ import platform
 import sys
 
 from src import NEEDED_PYTHON_VERSION
+from src.utils import time_print
 
 _needed_python_version_str = f"{NEEDED_PYTHON_VERSION[0]}.{NEEDED_PYTHON_VERSION[1]}"
 _used_python_version = sys.version_info
@@ -18,7 +19,7 @@ class _PythonVersionTooLowError(Exception):
 def check_python_version() -> None:
     """Raise an error if used Python version is too low."""
     if _used_python_version < NEEDED_PYTHON_VERSION:
-        print(f"This program requires Python {_needed_python_version_str} or higher.")
-        print(f"You are using Python {platform.python_version()}")
-        print("Please install a correct version of Python.")
+        time_print(f"This program requires Python {_needed_python_version_str} or higher.")
+        time_print(f"You are using Python {platform.python_version()}")
+        time_print("Please install a correct version of Python.")
         raise _PythonVersionTooLowError()


### PR DESCRIPTION
This PR adds support for the RPi5, I still recommend not to use pins initialized by default on the pi5, because gpiozero can just access not initialized pins. Pins during test being initialized at runtime are  (7,8,14,15,23,24,25).

Closes https://github.com/AndreWohnsland/CocktailBerry/issues/169