### PR TITLE
Make the rpi5 output device off by default

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ Here you will find everything to get started!
 It enables you to build your own, fully customized machine, while still be able to use the identical software on each machine.
 
 <div class="mid-flex">
+  <a href="https://cocktailberry.org/" class="cta-btn secondary-btn"> Homepage </a>
   <a href="quickstart/" class="cta-btn primary-btn"> Quickstart </a>
   <a href="setup/" class="cta-btn secondary-btn"> Set Up </a>
 </div>

--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,7 @@ If you want to support this project, feel free to fork it and create your own pu
 To get started, have a quick look into the [Guidelines for contributing](./CONTRIBUTING.md). Here is a general list of features or refactoring things, I may do in the future. With your help, these things come even faster! If your idea is not on the list, feel free to open a feature request, I may consider it!
 
 - `easy`: Translate all dialogs / UI to your native language
+- `medium`: Help to move to v2 with API based control and a separate UI
 - `easy-hard`: Implement a cool [addon](https://github.com/AndreWohnsland/CocktailBerry-Addons) and make it verified
 
 # Development

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-__version__ = "1.37.0"
+__version__ = "1.38.0"
 PROJECT_NAME = "CocktailBerry"
 MAX_SUPPORTED_BOTTLES = 24
 SupportedLanguagesType = Literal["en", "de"]

--- a/src/machine/raspberry.py
+++ b/src/machine/raspberry.py
@@ -131,7 +131,7 @@ class Rpi5Controller(PinController):
                     self.gpios[pin] = InputDevice(pin, pull_up=pull_up)
                 else:
                     # Initialize OutputDevice with active_high based on the inverted flag
-                    self.gpios[pin] = OutputDevice(pin, initial_value=self.low, active_high=self.active_high)
+                    self.gpios[pin] = OutputDevice(pin, initial_value=False, active_high=self.active_high)
             except Exception as e:
                 # Catch any error and continue, printing the pin and error message
                 logger.log_event("WARNING", f"Error: Could not initialize GPIO pin {pin}. Reason: {e!s}")


### PR DESCRIPTION
We cannot use self.low because it might be true, turning the pump on at init. Only an issue with the new control at the rpi5.