### PR TITLE
Make migrator always respect local config

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Update version in pyproject.toml
         run: |
-          sed -i "s/version = \".*\"/version = \"${{ steps.get_version.outputs.version }}\"/" pyproject.toml
+          sed -i "/^version = \".*\"$/s/version = \".*\"/version = \"${{ steps.get_version.outputs.version }}\"/" pyproject.toml
 
       - name: Commit changes
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ allow-direct-references = true
 # don't check import order in the migration script
 line-length = 120
 exclude = ["ui_elements", "addon_skeleton.py"]
-target-version = "1.38.1"
+target-version = "py39"
 
 [tool.ruff.lint]
 extend-safe-fixes = [

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import random
+import sys
 from typing import Any, Callable, ClassVar
 
 import typer
@@ -187,6 +188,14 @@ class ConfigManager:
             "EXP_MAKER_UNIT": StringType(),
             "EXP_MAKER_FACTOR": FloatType([build_number_limiter(0.01, 100)]),
         }
+        self.read_local_config()
+
+    def read_local_config(self):
+        """Read the local config file and set the values if they are valid.
+
+        Might throw a ConfigError if the config is not valid.
+        Ignore the error if the file is not found, as it is created at the first start of the program.
+        """
         with contextlib.suppress(FileNotFoundError):
             self._read_config()
 
@@ -360,4 +369,13 @@ def show_start_message(machine_name: str = PROJECT_NAME):
 
 
 shared = Shared()
-CONFIG = ConfigManager()
+# try to load the config, in case of error, print it and exit
+# this is less confusing than a stacktrace
+try:
+    CONFIG = ConfigManager()
+except ConfigError as e:
+    logger.error(f"Config Error: {e}")
+    logger.log_exception(e)
+    time_print(f"Config Error: {e}, please check the config file.")
+    time_print(f"You can edit the file at: {CUSTOM_CONFIG_FILE}")
+    sys.exit(1)

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import contextlib
 import random
-import sys
 from typing import Any, Callable, ClassVar
 
 import typer
@@ -188,9 +187,8 @@ class ConfigManager:
             "EXP_MAKER_UNIT": StringType(),
             "EXP_MAKER_FACTOR": FloatType([build_number_limiter(0.01, 100)]),
         }
-        self.read_local_config()
 
-    def read_local_config(self):
+    def read_local_config(self, update_config: bool = False):
         """Read the local config file and set the values if they are valid.
 
         Might throw a ConfigError if the config is not valid.
@@ -198,6 +196,8 @@ class ConfigManager:
         """
         with contextlib.suppress(FileNotFoundError):
             self._read_config()
+        if update_config:
+            self.sync_config_to_file()
 
     def sync_config_to_file(self):
         """Write the config attributes to the config file.
@@ -369,13 +369,4 @@ def show_start_message(machine_name: str = PROJECT_NAME):
 
 
 shared = Shared()
-# try to load the config, in case of error, print it and exit
-# this is less confusing than a stacktrace
-try:
-    CONFIG = ConfigManager()
-except ConfigError as e:
-    logger.error(f"Config Error: {e}")
-    logger.log_exception(e)
-    time_print(f"Config Error: {e}, please check the config file.")
-    time_print(f"You can edit the file at: {CUSTOM_CONFIG_FILE}")
-    sys.exit(1)
+CONFIG = ConfigManager()

--- a/src/dialog_handler.py
+++ b/src/dialog_handler.py
@@ -127,7 +127,7 @@ class DialogHandler:
 
     def password_prompt(
         self,
-        right_password: int = cfg.UI_MASTERPASSWORD,
+        right_password: int,
         header_type: Literal["master", "maker"] = "master",
     ):
         """Open a password prompt, return if successful entered password.

--- a/src/error_handler.py
+++ b/src/error_handler.py
@@ -33,7 +33,10 @@ def logerror(func: Callable):
             msg = f"The function {func.__name__} did run into an error at module: {module} function {fname} in row: {row}!"  # noqa
             _logger.log_exception(msg)
             time_print(msg)
-            MACHINE.close_all_pumps()
+            try:
+                MACHINE.close_all_pumps()
+            except Exception as e:
+                _logger.log_exception(f"Error while closing the pumps: {e}")
             raise
         return result
 

--- a/src/machine/controller.py
+++ b/src/machine/controller.py
@@ -35,12 +35,14 @@ class MachineController:
     """Controller Class for all Machine related Pin routines."""
 
     def __init__(self):
-        super().__init__()
-        self.pin_controller = self._chose_controller()
-        self._led_controller = LedController(self.pin_controller)
-        self._reverter = Reverter(self.pin_controller)
         # Time for print intervals, need to remember the last print time
         self._print_time = 0.0
+
+    def init_machine(self):
+        self._pin_controller = self._chose_controller()
+        self._led_controller = LedController(self._pin_controller)
+        self._reverter = Reverter(self._pin_controller, cfg.MAKER_PUMP_REVERSION, cfg.MAKER_REVERSION_PIN)
+        self.set_up_pumps()
 
     def _chose_controller(self) -> PinController:
         """Select the controller class for the Pin."""
@@ -185,14 +187,14 @@ class MachineController:
         used_config = cfg.PUMP_CONFIG[: cfg.MAKER_NUMBER_BOTTLES]
         active_pins = [x.pin for x in used_config]
         time_print(f"<i> Initializing Pins: {active_pins}")
-        self.pin_controller.initialize_pin_list(active_pins)
+        self._pin_controller.initialize_pin_list(active_pins)
         self._reverter.initialize_pin()
         atexit.register(self.cleanup)
 
     def _start_pumps(self, pin_list: list[int], print_prefix: str = ""):
         """Informs and opens all given pins."""
         time_print(f"{print_prefix}<o> Opening Pins: {pin_list}")
-        self.pin_controller.activate_pin_list(pin_list)
+        self._pin_controller.activate_pin_list(pin_list)
 
     def close_all_pumps(self):
         """Close all pins connected to the pumps."""
@@ -203,12 +205,12 @@ class MachineController:
     def cleanup(self):
         """Cleanup for shutdown the machine."""
         self.close_all_pumps()
-        self.pin_controller.cleanup_pin_list()
+        self._pin_controller.cleanup_pin_list()
 
     def _stop_pumps(self, pin_list: list[int], print_prefix: str = ""):
         """Informs and closes all given pins."""
         time_print(f"{print_prefix}<x> Closing Pins: {pin_list}")
-        self.pin_controller.close_pin_list(pin_list)
+        self._pin_controller.close_pin_list(pin_list)
 
     def default_led(self):
         """Turn the LED on."""

--- a/src/machine/gpio_factory.py
+++ b/src/machine/gpio_factory.py
@@ -1,6 +1,5 @@
 """Module to create the according GPIO controller for the appropriate Board."""
 
-from src.config.config_manager import CONFIG as cfg
 from src.machine.generic_board import GenericGPIO
 from src.machine.interface import GPIOController
 from src.machine.raspberry import RaspberryGPIO
@@ -11,12 +10,11 @@ class GPIOFactory:
         # global general inverted status
         self.inverted = inverted
 
-    def generate_gpio(self, inverted: bool, pin: int) -> GPIOController:
+    def generate_gpio(self, inverted: bool, pin: int, board: str) -> GPIOController:
         """Return the appropriate GPIO.
 
         Option to specific invert one GPIO relative to general setting.
         """
-        board = cfg.MAKER_BOARD
         # using xor here to created the right inverted status
         is_inverted = self.inverted ^ inverted
         if board == "RPI":

--- a/src/machine/leds.py
+++ b/src/machine/leds.py
@@ -21,7 +21,7 @@ except ModuleNotFoundError:
 
 class LedController:
     def __init__(self, pin_controller: PinController) -> None:
-        self.pin_controller = pin_controller
+        self._pin_controller = pin_controller
         self.pins = cfg.LED_PINS
         enabled = len(cfg.LED_PINS) > 0
         self.controllable = cfg.LED_IS_WS and MODULE_AVAILABLE
@@ -34,7 +34,7 @@ class LedController:
             return
         # If not controllable use normal LEDs
         if not cfg.LED_IS_WS:
-            self.led_list = [_normalLED(pin, self.pin_controller) for pin in self.pins]
+            self.led_list = [_normalLED(pin, self._pin_controller) for pin in self.pins]
             return
         # If controllable try to set up the WS281x LEDs
         try:
@@ -76,21 +76,21 @@ class _LED(Protocol):
 
 
 class _normalLED(_LED):
-    def __init__(self, pin: int, pin_controller: PinController) -> None:
+    def __init__(self, pin: int, _pin_controller: PinController) -> None:
         self.pin = pin
-        self.pin_controller = pin_controller
-        self.pin_controller.initialize_pin_list([self.pin])
+        self._pin_controller = _pin_controller
+        self._pin_controller.initialize_pin_list([self.pin])
 
     def __del__(self):
-        self.pin_controller.cleanup_pin_list([self.pin])
+        self._pin_controller.cleanup_pin_list([self.pin])
 
     def turn_on(self):
         """Turn the LEDs on."""
-        self.pin_controller.activate_pin_list([self.pin])
+        self._pin_controller.activate_pin_list([self.pin])
 
     def turn_off(self):
         """Turn the LEDs off."""
-        self.pin_controller.close_pin_list([self.pin])
+        self._pin_controller.close_pin_list([self.pin])
 
     def preparation_start(self):
         """Turn the LED on during preparation."""

--- a/src/machine/reverter.py
+++ b/src/machine/reverter.py
@@ -1,27 +1,27 @@
-from src.config.config_manager import CONFIG as cfg
 from src.machine.interface import PinController
 from src.utils import time_print
 
 
 class Reverter:
-    def __init__(self, pin_controller: PinController):
+    def __init__(self, pin_controller: PinController, use_reversion: bool, revert_pin: int):
         self._pin_controller = pin_controller
         # only init if reversion is enabled, otherwise it may be an invalid pin
-        self.revert_pin = cfg.MAKER_REVERSION_PIN
+        self.use_reversion = use_reversion
+        self.revert_pin = revert_pin
 
     def initialize_pin(self):
-        if cfg.MAKER_PUMP_REVERSION:
+        if self.use_reversion:
             time_print(f"Initializing Reversion Pin: {self.revert_pin}")
             self._pin_controller.initialize_pin_list([self.revert_pin])
 
     def revert_on(self):
         """Reverts the pump to be inverted."""
-        if not cfg.MAKER_PUMP_REVERSION:
+        if not self.use_reversion:
             return
         self._pin_controller.activate_pin_list([self.revert_pin])
 
     def revert_off(self):
         """Disables the reversion pin."""
-        if not cfg.MAKER_PUMP_REVERSION:
+        if not self.use_reversion:
             return
         self._pin_controller.close_pin_list([self.revert_pin])

--- a/src/migration/migrator.py
+++ b/src/migration/migrator.py
@@ -229,12 +229,14 @@ def _combine_pump_setting_into_one_config():
         return
     # get the value from the config, if not exists fall back to default
     pump_pins = configuration.get("PUMP_PINS", [14, 15, 18, 23, 24, 25, 8, 7, 17, 27])
-    pump_volume_flow = configuration.get("PUMP_VOLUMEFLOW", [30.0] * 10)
+    pump_volume_flow = configuration.get("PUMP_VOLUMEFLOW", [30.0] * 24)
     tube_volume = configuration.get("MAKER_TUBE_VOLUME", 0)
-    pump_config = []
+    pump_config: list[PumpConfig] = []
     for pin, volume_flow in zip(pump_pins, pump_volume_flow):
         pump_config.append(PumpConfig(pin, volume_flow, tube_volume))
     configuration["PUMP_CONFIG"] = pump_config
+    # also "fix" pump count, since it did happen that number of pump config was lower than this value
+    configuration["MAKER_NUMBER_BOTTLES"] = len(pump_config)
     with open(CUSTOM_CONFIG_FILE, "w", encoding="UTF-8") as stream:
         yaml.dump(configuration, stream, default_flow_style=False)
 

--- a/src/programs/calibration.py
+++ b/src/programs/calibration.py
@@ -20,6 +20,9 @@ class CalibrationScreen(QMainWindow, Ui_CalibrationWindow):
         super().__init__()
         self.setupUi(self)
         self.setWindowFlags(Qt.Window | Qt.CustomizeWindowHint | Qt.WindowStaysOnTopHint)  # type: ignore
+        if standalone:
+            cfg.read_local_config()
+            MACHINE.init_machine()
         # Connect the Button
         bottles = cfg.MAKER_NUMBER_BOTTLES
         self.PB_start.clicked.connect(self.output_volume)
@@ -31,8 +34,6 @@ class CalibrationScreen(QMainWindow, Ui_CalibrationWindow):
         self.showFullScreen()
         DP_CONTROLLER.inject_stylesheet(self)
         DP_CONTROLLER.set_display_settings(self)
-        if standalone:
-            MACHINE.set_up_pumps()
         logger.log_start_program("calibration")
 
     def output_volume(self):

--- a/src/tabs/ingredients.py
+++ b/src/tabs/ingredients.py
@@ -3,6 +3,7 @@
 This includes all functions for the Lists, DB and Buttons/Dropdowns.
 """
 
+from src.config.config_manager import CONFIG as cfg
 from src.database_commander import DB_COMMANDER
 from src.display_controller import DP_CONTROLLER
 from src.error_handler import logerror
@@ -123,7 +124,7 @@ def delete_ingredient(w):
         return
     if not DP_CONTROLLER.ask_to_delete_x(selected_ingredient):
         return
-    if not DP_CONTROLLER.password_prompt():
+    if not DP_CONTROLLER.password_prompt(cfg.UI_MASTERPASSWORD):
         return
 
     # Check if still used at a bottle or within a recipe

--- a/src/tabs/recipes.py
+++ b/src/tabs/recipes.py
@@ -5,6 +5,7 @@ This includes all functions for the Lists, DB and Buttons/Dropdowns.
 
 from collections import Counter
 
+from src.config.config_manager import CONFIG as cfg
 from src.database_commander import DB_COMMANDER
 from src.display_controller import DP_CONTROLLER
 from src.error_handler import logerror
@@ -198,7 +199,7 @@ def delete_recipe(w):
         return
     if not DP_CONTROLLER.ask_to_delete_x(recipe_name):
         return
-    if not DP_CONTROLLER.password_prompt():
+    if not DP_CONTROLLER.password_prompt(cfg.UI_MASTERPASSWORD):
         return
 
     DB_COMMANDER.delete_recipe(recipe_name)

--- a/src/ui/setup_cocktail_selection.py
+++ b/src/ui/setup_cocktail_selection.py
@@ -18,7 +18,6 @@ from src.ui.icons import ICONS
 from src.ui_elements import Ui_CocktailSelection
 
 T = TypeVar("T", int, float)
-PICTURE_SIZE = int(min(cfg.UI_WIDTH * 0.5, cfg.UI_HEIGHT * 0.60))
 
 if TYPE_CHECKING:
     from src.ui.setup_mainwindow import MainScreen
@@ -37,8 +36,9 @@ class CocktailSelection(QDialog, Ui_CocktailSelection):
         # build the image
         self.image_container.setScaledContents(True)
         self.image_container.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Ignored)  # type: ignore
-        self.image_container.setMinimumSize(PICTURE_SIZE, PICTURE_SIZE)
-        self.image_container.setMaximumSize(PICTURE_SIZE, PICTURE_SIZE)
+        picture_size = int(min(cfg.UI_WIDTH * 0.5, cfg.UI_HEIGHT * 0.60))
+        self.image_container.setMinimumSize(picture_size, picture_size)
+        self.image_container.setMaximumSize(picture_size, picture_size)
         ICONS.set_cocktail_selection_icons(self)
         self._adjust_preparation_buttons()
 

--- a/src/ui/setup_mainwindow.py
+++ b/src/ui/setup_mainwindow.py
@@ -83,7 +83,7 @@ class MainScreen(QMainWindow, Ui_MainWindow):
         DP_CONTROLLER.initialize_window_object(self)
 
         UI_LANGUAGE.adjust_mainwindow(self)
-        MACHINE.set_up_pumps()
+        MACHINE.init_machine()
         MACHINE.default_led()
         self.showFullScreen()
         # as long as its not UI_DEVENVIRONMENT (usually touchscreen) hide the cursor
@@ -192,7 +192,7 @@ class MainScreen(QMainWindow, Ui_MainWindow):
 
     def open_option_window(self):
         """Open up the options."""
-        if not DP_CONTROLLER.password_prompt():
+        if not DP_CONTROLLER.password_prompt(cfg.UI_MASTERPASSWORD):
             return
         self.option_window = OptionWindow(self)
 
@@ -331,7 +331,7 @@ class MainScreen(QMainWindow, Ui_MainWindow):
         if index in unprotected_tabs:
             self.previous_tab_index = index
             return
-        if DP_CONTROLLER.password_prompt(right_password=cfg.UI_MAKER_PASSWORD, header_type="maker"):
+        if DP_CONTROLLER.password_prompt(cfg.UI_MAKER_PASSWORD, header_type="maker"):
             self.previous_tab_index = index
             return
         # Set back to the prev tab if password not right

--- a/src/ui/setup_password_dialog.py
+++ b/src/ui/setup_password_dialog.py
@@ -3,7 +3,6 @@ from typing import Literal
 from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtWidgets import QMainWindow
 
-from src.config.config_manager import CONFIG as cfg
 from src.dialog_handler import UI_LANGUAGE
 from src.display_controller import DP_CONTROLLER
 from src.ui_elements.passworddialog import Ui_PasswordDialog
@@ -14,7 +13,7 @@ class PasswordDialog(QMainWindow, Ui_PasswordDialog):
 
     password_success = pyqtSignal(bool)  # Signal to communicate data
 
-    def __init__(self, right_password: int = cfg.UI_MASTERPASSWORD, header_type: Literal["master", "maker"] = "master"):
+    def __init__(self, right_password: int, header_type: Literal["master", "maker"] = "master"):
         """Init. Connect all the buttons and set window policy."""
         super().__init__()
         self.setupUi(self)

--- a/src/ui/setup_picture_window.py
+++ b/src/ui/setup_picture_window.py
@@ -3,15 +3,12 @@ from typing import Callable
 from PyQt5.QtGui import QImage, QPixmap
 from PyQt5.QtWidgets import QMainWindow
 
-from src.config.config_manager import CONFIG as cfg
 from src.dialog_handler import UI_LANGUAGE
 from src.display_controller import DP_CONTROLLER
 from src.image_utils import find_default_cocktail_image, find_user_cocktail_image, process_image, save_image
 from src.models import Cocktail
 from src.ui.icons import ICONS
 from src.ui_elements import Ui_PictureWindow
-
-PICTURE_SIZE = int(min(cfg.UI_WIDTH * 0.5, cfg.UI_HEIGHT * 0.65))
 
 
 class PictureWindow(QMainWindow, Ui_PictureWindow):


### PR DESCRIPTION
With some of the latest changes, an internal dependency of the migrator (mig>db>model>config) to the config was introduced, which resulted in an init of the config before the migrator. This was due to the use of a side effect within this class. Now the init of the class does not read in and validated the config, it needs to be explicitly initialized before the start of the main program. Necessary adjustments to local variables were made, to respect the new behavior.