### PR TITLE
fix uvloop to 0.20.0 in backend service

### DIFF
--- a/dashboard/backend/requirements.txt
+++ b/dashboard/backend/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.111.0
 uvicorn==0.29.0
+uvloop==0.20.0


### PR DESCRIPTION
With version 0.21.0 the docker build will fail due to the armv7 not supporting this (yet?)