### PR TITLE
Remove old CocktailBerry folder if it exist at installation

### DIFF
--- a/scripts/all_in_one.sh
+++ b/scripts/all_in_one.sh
@@ -91,6 +91,14 @@ echo "~ Getting the CocktailBerry project from GitHub ... ~"
 echo "It will be located at ~/CocktailBerry"
 # shellcheck disable=SC2164
 cd ~
+# if folder exist, backup the "custom_config.yaml" within it to ~/custom_config.yaml.bck
+if [ -d ~/CocktailBerry ]; then
+  echo "CocktailBerry folder already exists. Backup existing custom_config.yaml to ~/old_custom_config.yaml"
+  cp ~/CocktailBerry/custom_config.yaml ~/old_custom_config.yaml
+  echo "Removing old CocktailBerry folder if it exists ..."
+  sudo rm -rf ~/CocktailBerry
+fi
+# first remove the folder if it already exists
 git clone https://github.com/AndreWohnsland/CocktailBerry.git
 # shellcheck disable=SC2164
 cd ~/CocktailBerry

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -110,15 +110,15 @@ else
   fi
   # try to install python-periphery, so other devices may also use the gpio
   pip install python-periphery || echo "ERROR: Could not install python-periphery, if you are on a RPi, this is not needed"
+  # on none RPi devices, we need to set control to the GPIOs, and set user to sudoers
+  if ! is_raspberry_pi; then
+    ./setup_non_rpi.sh
+  fi
   # still cp the file, but do not inform the user anymore, since this is not the default anymore
   cp microservice/.env.example microservice/.env
   echo "Install qtsass, this may take a while depending on your OS, so it is time for a coffe break :)"
   echo "If this takes too long for you, you can cancel this step with 'ctrl + c' and install qtsass later manually with 'pip install qtsass'"
   echo "qtsass is needed if you want to customize the CocktailBerry GUI and use your own colors"
   pip install qtsass
-  # on none RPi devices, we need to set control to the GPIOs, and set user to sudoers
-  if ! is_raspberry_pi; then
-    ./setup_non_rpi.sh
-  fi
 fi
 echo "Done with the setup"


### PR DESCRIPTION
It might happen that user will use the script the reinstall the project. Some things, like the venv were already removed, but the git folder and hence the config was not. This is now fixed.
