### PR TITLE
Do not longer define board type in config

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -75,7 +75,6 @@ They can be used at own risk of CocktailBerry not working 100% properly.
     | `LED_DEFAULT_ON`       | Always turn on to a white LED by default                                                 |
     | `LED_IS_WS`            | Is the led a controllable WS281x LED, [see also](troubleshooting.md#get-the-led-working) |
     | `RFID_READER`          | Enables connected RFID reader, [more info](troubleshooting.md#set-up-rfid-reader)        |
-    | `MAKER_BOARD`          | Used [board](#configuring-the-pins-or-used-board) for Hardware                           |
     | `MAKER_PINS_INVERTED`  | [Inverts](faq.md#what-is-the-inverted-option) pin signal (on=low, off=high)              |
     | `MAKER_PUMP_REVERSION` | Enables reversion (direction) of pump                                                    |
     | `MAKER_REVERSION_PIN`  | [Pin](#configuring-the-pins-or-used-board) which triggers reversion                      |

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -123,9 +123,7 @@ See also [this FAQ](faq.md#what-is-the-available-button) for more information on
 
 ## Configuring the Pins or used Board
 
-To set up your Board, you can choose between different platforms.
-The according controlling library for Python needs to be installed.
-If it's not shipped within the default OS of your board, this will be mentioned here.
+Most boards should work with cocktailberry, the according controller will be automatically selected.
 Currently supported options (boards) are:
 
 - **RPI (Raspberry Pi)**: Using GPIO according to [GPIO-Numbers](https://pinout.xyz/) for Pins.
@@ -134,7 +132,6 @@ Currently supported options (boards) are:
 !!! info "Not your Board?"
     Even if your board is not listed here, it may work.
     This value is used to determinate the control method for the pins of the board.
-    If it's controlled identical to a listed board here, you can try to use this existing value for your board.
 
 ## Themes
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,7 +4,6 @@ __version__ = "1.38.1"
 PROJECT_NAME = "CocktailBerry"
 MAX_SUPPORTED_BOTTLES = 24
 SupportedLanguagesType = Literal["en", "de"]
-SupportedBoardType = Literal["RPI", "Generic"]
 SupportedThemesType = Literal["default", "bavaria", "alien", "berry", "custom"]
 SupportedRfidType = Literal["No", "MFRC522", "PiicoDev"]
 NEEDED_PYTHON_VERSION = (3, 9)

--- a/src/config/config_types.py
+++ b/src/config/config_types.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Generic, Protocol, TypeVar, get_args
 
 from src import (
-    SupportedBoardType,
     SupportedLanguagesType,
     SupportedRfidType,
     SupportedThemesType,
@@ -19,7 +18,6 @@ from src import (
 from src.config.errors import ConfigError
 
 SUPPORTED_LANGUAGES = list(get_args(SupportedLanguagesType))
-SUPPORTED_BOARDS = list(get_args(SupportedBoardType))
 SUPPORTED_THEMES = list(get_args(SupportedThemesType))
 SUPPORTED_RFID = list(get_args(SupportedRfidType))
 
@@ -69,7 +67,6 @@ class ChooseType(ConfigInterface):
 
 
 class ChooseOptions:
-    board = ChooseType(allowed=SUPPORTED_BOARDS)
     language = ChooseType(allowed=SUPPORTED_LANGUAGES)
     rfid = ChooseType(allowed=SUPPORTED_RFID)
     theme = ChooseType(allowed=SUPPORTED_THEMES)

--- a/src/language.yaml
+++ b/src/language.yaml
@@ -589,9 +589,6 @@ ui:
     MAKER_PINS_INVERTED:
       en: 'Inverts the pin signal (on is low, off is high), needed for most relays'
       de: 'Vertauscht das Pin Signal (an ist low, aus ist high), benötigt von vielen Relays'
-    MAKER_BOARD:
-      en: 'Type of microcomputer / board used'
-      de: 'Typ des Microcomputers / Boards'
     MAKER_THEME:
       en: 'Color theme of the application, use custom to select your own color'
       de: 'Farbeinstellung des Programms, wähle custom aus, um es selbst zu stylen'

--- a/src/machine/controller.py
+++ b/src/machine/controller.py
@@ -12,7 +12,7 @@ from src.config.config_manager import shared
 from src.machine.generic_board import GenericController
 from src.machine.interface import PinController
 from src.machine.leds import LedController
-from src.machine.raspberry import choose_pi_controller
+from src.machine.raspberry import choose_pi_controller, is_rpi
 from src.machine.reverter import Reverter
 from src.models import Ingredient
 from src.utils import time_print
@@ -46,7 +46,7 @@ class MachineController:
 
     def _chose_controller(self) -> PinController:
         """Select the controller class for the Pin."""
-        if cfg.MAKER_BOARD == "RPI":
+        if is_rpi():
             return choose_pi_controller(cfg.MAKER_PINS_INVERTED)
         # In case none is found, fall back to generic using python-periphery
         return GenericController(cfg.MAKER_PINS_INVERTED)

--- a/src/machine/raspberry.py
+++ b/src/machine/raspberry.py
@@ -31,7 +31,15 @@ def is_rpi5() -> bool:
     model = "No Model"
     with contextlib.suppress(FileNotFoundError), open("/proc/device-tree/model", encoding="utf-8") as f:
         model = f.read()
-    return "Raspberry Pi 5" in model
+    return "raspberry pi 5" in model.lower()
+
+
+def is_rpi() -> bool:
+    """Check if the current machine is a Raspberry Pi."""
+    model = "No Model"
+    with contextlib.suppress(FileNotFoundError), open("/proc/device-tree/model", encoding="utf-8") as f:
+        model = f.read()
+    return "raspberry pi" in model.lower()
 
 
 def choose_pi_controller(inverted: bool) -> PinController:

--- a/src/ui/create_config_window.py
+++ b/src/ui/create_config_window.py
@@ -323,7 +323,6 @@ class ConfigWindow(QMainWindow, Ui_ConfigWindow):
                 "MAKER_PUMP_REVERSION",
                 "MAKER_REVERSION_PIN",
                 "MAKER_PINS_INVERTED",
-                "MAKER_BOARD",
             ),
         }
         for key, value in exact_sorting.items():


### PR DESCRIPTION
This is now determined internally, especially if it is a RPI or not. No longer needs the config option. 

Closes #200 