### PR TITLE
Safely return after calibration

### DIFF
--- a/src/programs/cli.py
+++ b/src/programs/cli.py
@@ -70,6 +70,7 @@ def main(
     generate_custom_style_file()
     if calibration:
         run_calibration()
+        return
     run_cocktailberry()
 
 


### PR DESCRIPTION
This ensures that not the main program might be triggered after the calibration in standalone