### PR TITLE
rename squeekboard to virtual-keyboard command

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -66,7 +66,7 @@ If it should not show up when clicking on an input field, you can try to enable 
 ```bash
 source ~/.env-cocktailberry/bin/activate
 cd ~/CocktailBerry
-python runme.py add-squeekboard
+python runme.py add-virtual-keyboard
 ```
 
 ## Disable the Virtual Keyboard
@@ -76,7 +76,7 @@ If you enabled it via the command above and want to disable it again, you can do
 ```bash
 source ~/.env-cocktailberry/bin/activate
 cd ~/CocktailBerry
-python runme.py remove-squeekboard
+python runme.py remove-virtual-keyboard
 ```
 
 In case you have not enabled it via the command above, you can also disable it by removing over raspi-config.

--- a/src/programs/cli.py
+++ b/src/programs/cli.py
@@ -213,8 +213,8 @@ def switch_back():
 
 
 @cli.command()
-def add_squeekboard():
-    """Add and start the Squeekboard service.
+def add_virtual_keyboard():
+    """Add and start the virtual keyboard service.
 
     This will create, enable, and start the Squeekboard virtual keyboard service.
     The service will be set up to start automatically on boot.
@@ -224,8 +224,8 @@ def add_squeekboard():
 
 
 @cli.command()
-def remove_squeekboard():
-    """Stop and disable the Squeekboard service.
+def remove_virtual_keyboard():
+    """Stop and disable the virtual keyboard service.
 
     This will stop and disable the Squeekboard virtual keyboard service.
     The service will no longer start automatically on boot.


### PR DESCRIPTION
This is more generic in case we want to switch the keyboard service at any time. In addition, the user does not need to know the specifics when using the CLI.