### PR TITLE
use fastapi instead flask in microservice

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,3 @@ services:
       - 25:25
     environment:
       PORT: 5000
-      FLASK_DEBUG: 1

--- a/microservice/app.py
+++ b/microservice/app.py
@@ -1,99 +1,87 @@
-#!flask/bin/python
 import datetime
 import json
-import logging
 import os
 from threading import Thread
-from typing import Dict
 
 import requests
+import uvicorn
 from database import DatabaseHandler
 from dotenv import load_dotenv
-from flask import Flask, abort, jsonify, request
-from flask.logging import create_logger
+from fastapi import FastAPI, File, UploadFile
+from fastapi.logger import logger
+from fastapi.responses import JSONResponse
 from helper import generate_urls_and_headers
 from query_sender import try_send_query_data
 
+from models import Cocktail
+
 load_dotenv()
 
-app = Flask(__name__)
-logging.basicConfig(level=logging.INFO)
-_logger = create_logger(app)
+app = FastAPI()
 
 
-@app.route("/")
-def welcome():
-    return jsonify({"status": "api working"})
+@app.get("/")
+async def welcome():
+    return JSONResponse(content={"status": "api working"})
 
 
-@app.route("/hookhandler/cocktail", methods=["POST"])
-def post_cocktail_hook():
-    def post_to_hook(url: str, payload: str, headers: Dict, send_query: bool):
+@app.post("/hookhandler/cocktail")
+async def post_cocktail_hook(cocktail: Cocktail):
+    def post_to_hook(url: str, payload: str, headers: dict, send_query: bool):
         try:
             req = requests.post(url, data=payload, headers=headers, timeout=10)
-            _logger.info("%s: Posted to %s with payload: %s", req.status_code, url, payload)
-            # Check if there is still querries data which was not send previously
-            # Needs to be specified to send, since multiple threads would cause double sending
+            logger.info("%s: Posted to %s with payload: %s", req.status_code, url, payload)
             if send_query:
-                try_send_query_data(app)
+                try_send_query_data()
         except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            _logger.error("Could not connect to %s for the cocktail data!", url)
+            logger.error("Could not connect to %s for the cocktail data!", url)
             db_handler = DatabaseHandler()
             db_handler.save_failed_post(payload, url, headers)
-        # pylint: disable=broad-except
         except Exception as err:
-            _logger.error("Some other error occurred: %s", err)
-
-    if not request.json or "cocktailname" not in request.json:
-        abort(400)
+            logger.error("Some other error occurred: %s", err)
 
     make_date = datetime.datetime.now().strftime("%d/%m/%Y, %H:%M")
-    if "makedate" in request.json:
-        make_date = request.json["make_date"]
+    if cocktail.makedate is not None:
+        make_date = cocktail.makedate
 
-    cocktail = {
-        "cocktailname": request.json["cocktailname"],
-        "volume": request.json["volume"],
-        "machinename": request.json["machinename"],
-        "countrycode": request.json["countrycode"],
-        "ingredients": request.json["ingredients"],
+    cocktail_data = {
+        "cocktailname": cocktail.cocktailname,
+        "volume": cocktail.volume,
+        "machinename": cocktail.machinename,
+        "countrycode": cocktail.countrycode,
+        "ingredients": cocktail.ingredients,
         "makedate": make_date,
     }
     endpoint_data = generate_urls_and_headers()
-    payload = json.dumps(cocktail)
+    payload = json.dumps(cocktail_data)
     if not endpoint_data:
-        return jsonify({"text": "No endpoints activated"}), 201
+        return JSONResponse(content={"text": "No endpoints activated", "data": cocktail_data}, status_code=201)
 
     for pos, (url, headers) in enumerate(endpoint_data):
         send_query = pos == 0
         thread = Thread(
             target=post_to_hook,
-            args=(
-                url,
-                payload,
-                headers,
-                send_query,
-            ),
+            args=(url, payload, headers, send_query),
         )
         thread.start()
-    return jsonify({"text": "Post to cocktail webhook started"}), 201
+    return JSONResponse(content={"text": "Post to cocktail webhook started"}, status_code=201)
 
 
-@app.route("/data-export", methods=["POST"])
-def post_file_with_mail():
-    data_file = request.files["upload_file"]
-    # TODO: Implement new sender / Endpoint
-    text = f"Not implemented sending data. Datatype is {type(data_file)}"
-    _logger.info(text)
-    return jsonify({"text": text}), 200
+@app.post("/data-export")
+async def post_file_with_mail(upload_file: UploadFile = File(...)):
+    text = f"Not implemented sending data. Datatype is {type(upload_file)}"
+    logger.info(text)
+    return JSONResponse(content={"text": text}, status_code=200)
 
 
-@app.route("/debug", methods=["POST", "GET", "PUT"])
-def debug_ep():
-    _logger.info(request.json)
-    return jsonify({"text": "debug"}), 200
+@app.post("/debug")
+@app.get("/debug")
+@app.put("/debug")
+async def debug_ep(cocktail: dict | None = None):
+    logger.info(cocktail)
+    return JSONResponse(content={"text": "debug"}, status_code=200)
 
 
 if __name__ == "__main__":
-    try_send_query_data(app)
-    app.run(host="0.0.0.0", port=int(os.getenv("PORT", "5000")))
+    try_send_query_data()
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "5000")))

--- a/microservice/helper.py
+++ b/microservice/helper.py
@@ -1,5 +1,4 @@
 import os
-from typing import Dict, List, Tuple
 
 DEFAULT_HOOK_EP = "enpointforhook"
 DEFAULT_API_KEY = "readdocshowtoget"
@@ -7,8 +6,8 @@ OLD_API_ENDPOINT = "https://cocktailberryapi-1-u0613408.deta.app/cocktail"
 API_ENDPOINT = "https://api.cocktailberry.org/api/v1/cocktail"
 
 
-def generate_urls_and_headers() -> List[Tuple[str, Dict[str, str]]]:
-    """Generates the urls as well as the header from the .env data"""
+def generate_urls_and_headers() -> list[tuple[str, dict[str, str]]]:
+    """Generate the urls as well as the header from the .env data."""
     hook_url = os.getenv("HOOK_ENDPOINT")
     api_key = os.getenv("API_KEY")
     hook_headers_config = os.getenv("HOOK_HEADERS", None)

--- a/microservice/models.py
+++ b/microservice/models.py
@@ -1,0 +1,12 @@
+from typing import Any, Optional
+
+from pydantic import BaseModel
+
+
+class Cocktail(BaseModel):
+    cocktailname: str
+    volume: int
+    machinename: str
+    countrycode: str
+    ingredients: list[dict[str, Any]]
+    makedate: Optional[str] = None

--- a/microservice/query_sender.py
+++ b/microservice/query_sender.py
@@ -1,32 +1,32 @@
 import json
-import requests
-from flask import Flask
-from database import DatabaseHandler
 
+import requests
+from database import DatabaseHandler
+from fastapi.logger import logger
 from helper import API_ENDPOINT, OLD_API_ENDPOINT
 
 
-def try_send_query_data(app: Flask):
+def try_send_query_data():
     db_handler = DatabaseHandler()
     failed_data = db_handler.get_failed_data()
     # Return if nothing to do
     if not failed_data:
         return
     # Else try to send all remaining data
-    app.logger.info("Found some not sended data, trying to send ...")
+    logger.info("Found some not sended data, trying to send ...")
     for send_id, data, url, headers in failed_data:
         # overwrite old endpoint
         if url == OLD_API_ENDPOINT:
             url = API_ENDPOINT
         try:
             res = requests.post(url, data=data, headers=json.loads(headers), timeout=10)
-            app.logger.info(f"Code: {res.status_code}, to: {url}, Payload: {data}")
+            logger.info(f"Code: {res.status_code}, to: {url}, Payload: {data}")
         except requests.exceptions.ConnectionError:
-            app.logger.error("There is still no connection")
+            logger.error("There is still no connection")
             return
         # pylint: disable=broad-except
         except Exception as err:
-            app.logger.error(f"Some other error occurred: {err}")
+            logger.error(f"Some other error occurred: {err}")
             return
         # if send successfully, delete this entry
         else:

--- a/microservice/requirements.txt
+++ b/microservice/requirements.txt
@@ -1,3 +1,4 @@
-Flask==2.3.3
+fastapi[standard]==0.115.6
+uvicorn==0.34.0
 requests==2.31.0
 python-dotenv==1.0.1


### PR DESCRIPTION
This is to streamline the backend framework usage, here was the only place we still used flask instead of fastapi.