### PR TITLE
Restart api after config change

### DIFF
--- a/src/language.yaml
+++ b/src/language.yaml
@@ -245,8 +245,8 @@ dialog:
     en: 'Cleaning process started!'
     de: 'Reinigung gestartet!'
   options_updated:
-    en: 'Options updated!'
-    de: 'Optionen aktualisiert!'
+    en: 'Options updated! Backend will be restarted.'
+    de: 'Optionen aktualisiert! Backend wird neu gestartet.'
 
 # Change of language in UI elements
 ui:

--- a/src/utils.py
+++ b/src/utils.py
@@ -92,10 +92,16 @@ def set_system_datetime(datetime_string: str):
 
 def restart_program():
     """Restart the CocktailBerry application."""
+    arguments = sys.argv[1:]
+    # skip out if this is the dev program (will not work restart here)
+    # This is because we run it with fastapi dev instead the python runme.py ...
+    if arguments[0] == "dev":
+        time_print("Will not restart because of dev program.")
+        return
     # trigger manually, since exec function will not trigger exit fun.
     atexit._run_exitfuncs()  # pylint: disable=protected-access
     python = sys.executable
-    os.execl(python, python, EXECUTABLE, *sys.argv[1:])
+    os.execl(python, python, EXECUTABLE, *arguments)
 
 
 def generate_custom_style_file():


### PR DESCRIPTION
This is needed for some attributes used during setup (e.g. pump pins) to apply after a config change. Also does no restart if running in fastapi dev mode, because then the restart would not work here.
Otherwise, for these changes to apply, the user have to manually restart the API or reboot the machine.