### PR TITLE
Add addon cocktail_trigger function

### DIFF
--- a/src/api/api.py
+++ b/src/api/api.py
@@ -49,6 +49,7 @@ async def lifespan(app: FastAPI):
         download_latest_web_client()
         updater = Updater()
         updater.update()
+    ADDONS.start_trigger_loop()
     yield
     MACHINE.cleanup()
 

--- a/src/api/internal/preparation.py
+++ b/src/api/internal/preparation.py
@@ -1,0 +1,14 @@
+from src.config.config_manager import shared
+from src.models import Cocktail, PrepareResult
+from src.tabs import maker
+
+
+def api_addon_prepare_flow(cocktail: Cocktail) -> tuple[bool, str]:
+    """Prepare a cocktail in the API UI."""
+    result, message, _ = maker.validate_cocktail(cocktail)
+    if result != PrepareResult.VALIDATION_OK:
+        return False, message
+    shared.team_member_name = None
+    shared.selected_team = "No Team"
+    _, message = maker.prepare_cocktail(cocktail)
+    return True, message

--- a/src/programs/addon_skeleton.py
+++ b/src/programs/addon_skeleton.py
@@ -11,7 +11,7 @@ from src.config.config_manager import CONFIG as cfg
 from src.config.errors import ConfigError
 
 # You can access the default database with help of the dbc
-from src.database_commander import DB_COMMANDER as dbc
+from src.database_commander import DatabaseCommander
 
 # Use the uil to add description and according translation
 from src.dialog_handler import UI_LANGUAGE as uil
@@ -22,6 +22,7 @@ from src.display_controller import DP_CONTROLLER as dpc
 # Use the LoggerHandler class for your logger
 from src.logger_handler import LoggerHandler
 
+from src.models import Cocktail
 # The addon interface will provide intellisense for all possible methods
 from src.programs.addons import AddonInterface
 
@@ -46,6 +47,14 @@ class Addon(AddonInterface):
 
     def after_cocktail(self, data: dict[str, Any]):
         """Run this method after the cocktail preparation."""
+
+    def cocktail_trigger(self, prepare: Callable[[Cocktail], tuple[bool, str]]):
+        """Will be executed in the background loop and can trigger a cocktail preparation.
+
+        Use the prepare function to start a cocktail preparation with prepare(cocktail).
+        It will return True, if the cocktail preparation was successful, otherwise False.
+        In addition, there is a message, which can contain further information.
+        """
 
     def build_gui(self, container: QVBoxLayout, button_generator: Callable[[str, Callable[[], None]], None]) -> bool:
         """Build up the GUI to do additional things on command.

--- a/src/ui/setup_cocktail_selection.py
+++ b/src/ui/setup_cocktail_selection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, TypeVar
+from typing import TYPE_CHECKING, Callable
 
 from PyQt5.QtGui import QFont, QPixmap
 from PyQt5.QtWidgets import QDialog, QLabel, QSizePolicy
@@ -17,8 +17,6 @@ from src.tabs.maker import PrepareResult
 from src.ui.creation_utils import LARGE_FONT, create_button, create_label, set_strike_through, set_underline
 from src.ui.icons import ICONS
 from src.ui_elements import Ui_CocktailSelection
-
-T = TypeVar("T", int, float)
 
 if TYPE_CHECKING:
     from src.ui.setup_mainwindow import MainScreen
@@ -295,12 +293,6 @@ class CocktailSelection(QDialog, Ui_CocktailSelection):
             icon = ICONS.generate_icon(icon_name, ICONS.color.background)
             ICONS.set_icon(button, icon, False)
             self.container_prepare_button.addWidget(button)
-
-
-def _limit_number(val: T, min_val: T, max_val: T) -> T:
-    """Limits the number in the boundaries."""
-    limited = max(min_val, val)
-    return min(max_val, limited)
 
 
 def _generate_needed_cocktail_icons(amount: int):

--- a/src/ui/setup_cocktail_selection.py
+++ b/src/ui/setup_cocktail_selection.py
@@ -12,10 +12,9 @@ from src.dialog_handler import UI_LANGUAGE
 from src.display_controller import DP_CONTROLLER
 from src.image_utils import find_cocktail_image
 from src.models import Cocktail, Ingredient
-from src.tabs import bottles, maker
-from src.tabs.maker import PrepareResult
 from src.ui.creation_utils import LARGE_FONT, create_button, create_label, set_strike_through, set_underline
 from src.ui.icons import ICONS
+from src.ui.shared import qt_prepare_flow
 from src.ui_elements import Ui_CocktailSelection
 
 if TYPE_CHECKING:
@@ -84,35 +83,7 @@ class CocktailSelection(QDialog, Ui_CocktailSelection):
         if db_cocktail is not None:
             self.cocktail = db_cocktail
         self._scale_cocktail(amount)
-        result, message, _ = maker.validate_cocktail(self.cocktail)
-
-        # Go to refill dialog, if this window is not locked
-        if (result == PrepareResult.NOT_ENOUGH_INGREDIENTS) and (
-            cfg.UI_MAKER_PASSWORD == 0 or not cfg.UI_LOCKED_TABS[2]
-        ):
-            self.mainscreen.open_refill_dialog(self.cocktail)
-            return
-
-        # No special case: just show the message
-        if result != PrepareResult.VALIDATION_OK:
-            DP_CONTROLLER.standard_box(message, close_time=60)
-            return
-        # Only show team dialog if it is enabled
-        if cfg.TEAMS_ACTIVE:
-            self.mainscreen.open_team_window()
-
-        result, message = maker.prepare_cocktail(self.cocktail, self.mainscreen)
-        # show dialog in case of cancel or if there are handadds
-        if result == PrepareResult.CANCELED:
-            DP_CONTROLLER.say_cocktail_canceled()
-        elif len(self.cocktail.handadds) > 0:
-            DP_CONTROLLER.standard_box(message, close_time=60)
-
-        # Otherwise clean up the rest
-        self.virgin_checkbox.setChecked(False)
-        bottles.set_fill_level_bars(self.mainscreen)
-        DP_CONTROLLER.reset_alcohol_factor()
-        self.mainscreen.container_maker.setCurrentWidget(self.mainscreen.cocktail_view)
+        qt_prepare_flow(self.mainscreen, self.cocktail)
 
     def _scale_cocktail(self, amount: int | None = None):
         """Scale the cocktail to given conditions for volume and alcohol."""

--- a/src/ui/setup_mainwindow.py
+++ b/src/ui/setup_mainwindow.py
@@ -19,6 +19,7 @@ from src.display_controller import DP_CONTROLLER, ItemDelegate
 from src.logger_handler import LoggerHandler
 from src.machine.controller import MACHINE
 from src.models import Cocktail
+from src.programs.addons import ADDONS
 from src.startup_checks import can_update, connection_okay, is_python_deprecated
 from src.tabs import bottles, ingredients, recipes
 from src.ui.cocktail_view import CocktailView
@@ -99,6 +100,7 @@ class MainScreen(QMainWindow, Ui_MainWindow):
         self.update_check()
         self._connection_check()
         self._deprecation_check()
+        ADDONS.start_trigger_loop(self)
 
     def update_check(self):
         """Check if there is an update and asks to update, if exists."""

--- a/src/ui/setup_mainwindow.py
+++ b/src/ui/setup_mainwindow.py
@@ -54,6 +54,10 @@ class MainScreen(QMainWindow, Ui_MainWindow):
         # limit bottles to 24 for this QT app (web can handle any number)
         cfg.MAKER_NUMBER_BOTTLES = min(cfg.MAKER_NUMBER_BOTTLES, 24)
 
+        # Removes the elements not used depending on number of bottles in bottle tab
+        # This also does adjust DB inserting data, since in the not used bottles may a ingredient be registered
+        DP_CONTROLLER.adjust_bottle_number_displayed(self)
+
         # init the empty further screens
         self.numpad_window: Optional[NumpadWidget] = None
         self.keyboard_window: Optional[KeyboardWidget] = None
@@ -291,10 +295,6 @@ class MainScreen(QMainWindow, Ui_MainWindow):
         # add custom icon delegate to search list
         self.list_widget_found_cocktails.setItemDelegate(ItemDelegate(self))
         self.list_widget_found_cocktails.setIconSize(BUTTON_SIZE)
-
-        # Removes the elements not used depending on number of bottles in bottle tab
-        # This also does adjust DB inserting data, since in the not used bottles may a ingredient be registered
-        DP_CONTROLLER.adjust_bottle_number_displayed(self)
 
         # gets the bottle ingredients into the global list
         bottles.get_bottle_ingredients()

--- a/src/ui/shared.py
+++ b/src/ui/shared.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.config.config_manager import CONFIG as cfg
+from src.display_controller import DP_CONTROLLER
+from src.models import Cocktail, PrepareResult
+from src.tabs import bottles, maker
+
+if TYPE_CHECKING:
+    from src.ui.setup_mainwindow import MainScreen
+
+
+def qt_prepare_flow(w: MainScreen, cocktail: Cocktail) -> tuple[bool, str]:
+    """Prepare a cocktail in the QT UI.
+
+    Switch to the maker screen at the end (if successful).
+    Show error/validation message or execute needed actions.
+    """
+    result, message, _ = maker.validate_cocktail(cocktail)
+
+    # Go to refill dialog, if this window is not locked
+    if (result == PrepareResult.NOT_ENOUGH_INGREDIENTS) and (cfg.UI_MAKER_PASSWORD == 0 or not cfg.UI_LOCKED_TABS[2]):
+        w.open_refill_dialog(cocktail)
+        return False, message
+
+    # No special case: just show the message
+    if result != PrepareResult.VALIDATION_OK:
+        DP_CONTROLLER.standard_box(message, close_time=60)
+        return False, message
+    # Only show team dialog if it is enabled
+    if cfg.TEAMS_ACTIVE:
+        w.open_team_window()
+
+    result, message = maker.prepare_cocktail(cocktail, w)
+    # show dialog in case of cancel or if there are handadds
+    if result == PrepareResult.CANCELED:
+        DP_CONTROLLER.say_cocktail_canceled()
+    elif len(cocktail.handadds) > 0:
+        DP_CONTROLLER.standard_box(message, close_time=60)
+
+    # Otherwise clean up the rest
+    if w.cocktail_selection:
+        w.cocktail_selection.virgin_checkbox.setChecked(False)
+    bottles.set_fill_level_bars(w)
+    DP_CONTROLLER.reset_alcohol_factor()
+    w.container_maker.setCurrentWidget(w.cocktail_view)
+    return True, message


### PR DESCRIPTION
This PR implements another option for the add-ons, `cocktail_trigger`.
This will run a continuous loop where the provided function will be executed.
With the available prepare method, the programmer can prepare a given cocktail.
This way, add-ons can trigger a cocktail other than over the GUI.

Take note that v2 once could also write his own microservice calling the cocktail prepare endpoint to have a somewhat similar behavior.