### PR TITLE
Wait 500ms between each addon cocktail (re)trigger

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -124,7 +124,10 @@ class Addon(AddonInterface): # (2)!
     def after_cocktail(self, data: dict): # (6)!
         pass
 
-    def cocktail_trigger(self, prepare: Callable[[Cocktail], tuple[bool, str]]): # (7)!
+    def cocktail_trigger(
+        self,
+        prepare: Callable[[Cocktail], tuple[bool, str]]
+    ): # (7)!
         pass
 
     def build_gui(

--- a/src/programs/addons.py
+++ b/src/programs/addons.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import atexit
 import re
 import threading
+import time
 from importlib import import_module
 from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol
 
@@ -93,6 +94,7 @@ class AddOnManager:
 
         def run_in_background(addon, prepare_function):
             while True:
+                time.sleep(0.5)
                 try:
                     func: Callable = getattr(addon, "cocktail_trigger")
                     func(prepare_function)


### PR DESCRIPTION
Running this too aggressive causes performance issues in case the add-on has no internal logic.