### PR TITLE
Catch and log ModuleNotFoundError in addons

### DIFF
--- a/src/machine/controller.py
+++ b/src/machine/controller.py
@@ -39,9 +39,9 @@ class MachineController:
         self._print_time = 0.0
 
     def init_machine(self):
-        self._pin_controller = self._chose_controller()
-        self._led_controller = LedController(self._pin_controller)
-        self._reverter = Reverter(self._pin_controller, cfg.MAKER_PUMP_REVERSION, cfg.MAKER_REVERSION_PIN)
+        self.pin_controller = self._chose_controller()
+        self.led_controller = LedController(self.pin_controller)
+        self.reverter = Reverter(self.pin_controller, cfg.MAKER_PUMP_REVERSION, cfg.MAKER_REVERSION_PIN)
         self.set_up_pumps()
 
     def _chose_controller(self) -> PinController:
@@ -62,10 +62,10 @@ class MachineController:
             w.open_progression_window("Cleaning")
         _header_print("Start Cleaning")
         if revert_pumps:
-            self._reverter.revert_on()
+            self.reverter.revert_on()
         self._start_preparation(w, prep_data, False)
         if revert_pumps:
-            self._reverter.revert_off()
+            self.reverter.revert_off()
         _header_print("Done Cleaning")
         if w is not None:
             w.close_progression_window()
@@ -106,10 +106,10 @@ class MachineController:
         prep_data = _build_preparation_data(ingredient_list)
         _header_print(f"Starting {recipe}")
         if is_cocktail:
-            self._led_controller.preparation_start()
+            self.led_controller.preparation_start()
         current_time, max_time = self._start_preparation(w, prep_data, verbose)
         if is_cocktail:
-            self._led_controller.preparation_end()
+            self.led_controller.preparation_end()
         consumption = [round(x.consumption) for x in prep_data]
         time_print(f"Total calculated consumption: {consumption}")
         _header_print(f"Finished {recipe}")
@@ -193,14 +193,14 @@ class MachineController:
         used_config = cfg.PUMP_CONFIG[: cfg.MAKER_NUMBER_BOTTLES]
         active_pins = [x.pin for x in used_config]
         time_print(f"<i> Initializing Pins: {active_pins}")
-        self._pin_controller.initialize_pin_list(active_pins)
-        self._reverter.initialize_pin()
+        self.pin_controller.initialize_pin_list(active_pins)
+        self.reverter.initialize_pin()
         atexit.register(self.cleanup)
 
     def _start_pumps(self, pin_list: list[int], print_prefix: str = ""):
         """Informs and opens all given pins."""
         time_print(f"{print_prefix}<o> Opening Pins: {pin_list}")
-        self._pin_controller.activate_pin_list(pin_list)
+        self.pin_controller.activate_pin_list(pin_list)
 
     def close_all_pumps(self):
         """Close all pins connected to the pumps."""
@@ -211,16 +211,16 @@ class MachineController:
     def cleanup(self):
         """Cleanup for shutdown the machine."""
         self.close_all_pumps()
-        self._pin_controller.cleanup_pin_list()
+        self.pin_controller.cleanup_pin_list()
 
     def _stop_pumps(self, pin_list: list[int], print_prefix: str = ""):
         """Informs and closes all given pins."""
         time_print(f"{print_prefix}<x> Closing Pins: {pin_list}")
-        self._pin_controller.close_pin_list(pin_list)
+        self.pin_controller.close_pin_list(pin_list)
 
     def default_led(self):
         """Turn the LED on."""
-        self._led_controller.default_led()
+        self.led_controller.default_led()
 
     def _consumption_print(self, consumption: list[float], current_time: float, max_time: float, interval=1):
         """Display each interval seconds information for cocktail preparation."""

--- a/src/programs/addons.py
+++ b/src/programs/addons.py
@@ -55,14 +55,20 @@ class AddOnManager:
         filenames = [x.stem for x in addon_files if "__init__" not in x.stem]
         self.addons: dict[str, AddonInterface] = {}
         for filename in filenames:
-            module = import_module(f"addons.{filename}")
+            try:
+                module = import_module(f"addons.{filename}")
+            except ModuleNotFoundError as e:
+                message = f"Could not import addon: {filename} due to <{e}>, please check addon or contact provider."
+                _logger.log_event("ERROR", message)
+                time_print(message)
+                continue
             name = filename
             if hasattr(module, "ADDON_NAME"):
                 name = module.ADDON_NAME
             # Check if the module implemented the addon class, otherwise log error and skip module
             if not hasattr(module, "Addon"):
                 _logger.log_event(
-                    "ERROR", f"Could not get Addon class from {name}, please check addon or contact provider."
+                    "WARNING", f"Could not get Addon class from {name}, please check addon or contact provider."
                 )
                 continue
             addon = getattr(module, "Addon")

--- a/src/programs/addons.py
+++ b/src/programs/addons.py
@@ -48,6 +48,13 @@ class AddonInterface(Protocol):
         """Logic to build up the addon GUI."""
         return False
 
+    def cocktail_trigger(self, prepare: Callable[[Cocktail], tuple[bool, str]]):
+        """Will be executed in the background loop and can trigger a cocktail preparation.
+
+        Use the prepare function to start a cocktail preparation with prepare(cocktail).
+        Return if cocktail preparation was successful and a message.
+        """
+
 
 class AddOnManager:
     """Class to handle the execution of all the addons."""


### PR DESCRIPTION
This might happen if the add-on provider import some not existing modules, like when they forget to install the library or miss a file.
This currently prevents CocktailBerry to start.
Now the add-on just gets not loaded and we log an error.