### PR TITLE
Build demo app with github pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,52 @@
+name: Build Demo App on GitHub Pages
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: 
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # only checkout the client folder
+          sparse-checkout: web_client
+          sparse-checkout-cone-mode: false
+
+      - name: Move mobile app files to root
+        run: |
+          ls -lah
+          shopt -s dotglob
+          mv web_client/* .
+          rm -rf web_client
+          ls -lah
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run install
+        uses: borales/actions-yarn@v5
+        with:
+          cmd: install
+
+      - name: Build production bundle
+        uses: borales/actions-yarn@v5
+        with:
+          cmd: build
+        env:
+          VITE_APP_API_URL: http://apidemo.cocktailberry.org/api/
+          
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: demo-pages


### PR DESCRIPTION
We will use GH pages for now for the demo app. The backend is hosted on a VPS, running in demo mode not allowing destructive actions.