### PR TITLE
Fix application not restarting in v1

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -95,7 +95,7 @@ def restart_program():
     arguments = sys.argv[1:]
     # skip out if this is the dev program (will not work restart here)
     # This is because we run it with fastapi dev instead the python runme.py ...
-    if arguments[0] == "dev":
+    if len(arguments) != 0 and arguments[0] == "dev":
         time_print("Will not restart because of dev program.")
         return
     # trigger manually, since exec function will not trigger exit fun.


### PR DESCRIPTION
Within the old application CLI there are no arguments. This prevents the restart to work in v1