### PR TITLE
fix detection of wrong script type in old setups

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,6 @@
     "Sideview"
   ],
   "cSpell.language": "en,de",
-  "ruff.lint.args": ["--line-length=120"],
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff"
   },

--- a/src/migration/migrator.py
+++ b/src/migration/migrator.py
@@ -328,7 +328,7 @@ def _install_uv():
 
 def _check_and_replace_qt_launcher_script():
     # check if the script has the basic python runme.py command without api
-    needed_commands = ["python runme.py", "export QT_SCALE_FACTOR=1"]
+    needed_commands = ["runme.py"]
     current_script_text = script_entry_path.read_text()
     with contextlib.suppress(FileNotFoundError):
         _logger.info("Updating the launcher script to the new version with uv")

--- a/src/tabs/maker.py
+++ b/src/tabs/maker.py
@@ -125,7 +125,7 @@ def validate_cocktail(cocktail: Cocktail) -> tuple[PrepareResult, str, Ingredien
             empty_ingredient.amount,
         )
         if cfg.UI_MAKER_PASSWORD != 0 and cfg.UI_LOCKED_TABS[2]:
-            msg += f' \n\n{DH.get_translation("bottle_tab_locked")}'
+            msg += f" \n\n{DH.get_translation('bottle_tab_locked')}"
         return PrepareResult.NOT_ENOUGH_INGREDIENTS, msg, empty_ingredient
     try:
         ADDONS.before_cocktail(addon_data)


### PR DESCRIPTION
Only check if runme.py is present for replacement
Issue is that very old scripts might not have the QT line and we switch to wrong launcher there.