### PR TITLE
fix memory leak in cocktail detail view lifecycle

### DIFF
--- a/src/ui/setup_mainwindow.py
+++ b/src/ui/setup_mainwindow.py
@@ -135,7 +135,13 @@ class MainScreen(QMainWindow, Ui_MainWindow):
     def open_cocktail_selection(self, cocktail: Cocktail):
         """Open the cocktail selection screen."""
         if self.cocktail_selection is not None:
+            # Clean up all internal layouts and widgets recursively
+            DP_CONTROLLER.delete_items_of_layout(self.cocktail_selection.layout())
+            # Remove from stacked widget
             self.container_maker.removeWidget(self.cocktail_selection)
+            # Schedule for deletion and remove reference
+            self.cocktail_selection.deleteLater()
+            self.cocktail_selection = None
         self.cocktail_selection = CocktailSelection(
             self, cocktail, lambda: self.container_maker.setCurrentWidget(self.cocktail_view)
         )
@@ -163,7 +169,9 @@ class MainScreen(QMainWindow, Ui_MainWindow):
 
     def open_progression_window(self, cocktail_type: str = "Cocktail"):
         """Open up the progression window to show the Cocktail status."""
-        self.progress_window = ProgressScreen(self, cocktail_type)
+        if self.progress_window is None:
+            self.progress_window = ProgressScreen(self, cocktail_type)
+        self.progress_window.show_screen(cocktail_type)
 
     def change_progression_window(self, pb_value: int):
         """Change the value of the progression bar of the ProBarWindow."""
@@ -175,7 +183,7 @@ class MainScreen(QMainWindow, Ui_MainWindow):
         """Close the progression window at the end of the cycle."""
         if self.progress_window is None:
             return
-        self.progress_window.close()
+        self.progress_window.hide()
 
     def open_team_window(self):
         self.team_window = TeamScreen(self)

--- a/src/ui/setup_progress_screen.py
+++ b/src/ui/setup_progress_screen.py
@@ -16,6 +16,10 @@ class ProgressScreen(QMainWindow, Ui_Progressbarwindow):
         DP_CONTROLLER.initialize_window_object(self)
         self.PBabbrechen.clicked.connect(interrupt_cocktail)
         self.mainscreen = parent
+        self.show_screen(cocktail_type)
+
+    def show_screen(self, cocktail_type="Cocktail"):
+        """Show the Progress screen."""
         UI_LANGUAGE.adjust_progress_screen(self, cocktail_type)
         self.showFullScreen()
         DP_CONTROLLER.set_display_settings(self)


### PR DESCRIPTION
The children of the cocktail selection view were not explicitly remove before widget removal, causing them to still persist in memory after parent deletion. This resulted in an application memory size increase of approx. 7 MB each time after the first time when the user selected the detailed view of a cocktail.
Long runtimes (as for a whole party with many people) as well as undecided guests could make this memory leak go so much up that the Pi would run OOM and the application would crash.

Closes https://github.com/AndreWohnsland/CocktailBerry/issues/279