### PR TITLE
fix compose not installing properly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: shellcheck
         name: ☕️ Ensure Shell Scripts are good with ShellCheck
         files: .*\.sh$
-        args: [-x]
+        args: [-x, -e, SC1017]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.15.0
     hooks:

--- a/scripts/install_compose.sh
+++ b/scripts/install_compose.sh
@@ -22,10 +22,10 @@ pip install -q lastversion
 
 if [ "$(getconf LONG_BIT)" = "64" ]; then
   echo "> Detected 64 bit system, using aarch64 compose image"
-  DOWNLOAD_URL=$(lastversion --assets --filter '\-linux-aarch64(?!.sha256)' docker/compose)
+  DOWNLOAD_URL=$(lastversion --assets --filter '\-linux-aarch64$' docker/compose)
 else
   echo "> Detected 32 bit system, using armv7l compose image"
-  DOWNLOAD_URL=$(lastversion --assets --filter '\-linux-armv7(?!.sha256)' docker/compose)
+  DOWNLOAD_URL=$(lastversion --assets --filter '\-linux-armv7l$' docker/compose)
 fi
 curl -SL "$DOWNLOAD_URL" -o "$DOCKER_CONFIG/cli-plugins/docker-compose"
 chmod +x "$DOCKER_CONFIG/cli-plugins/docker-compose"


### PR DESCRIPTION
This is due to a change (added provenance.json and sbom.json files) to the releases. We had a list and not a value of release images.