### PR TITLE
prevent preparation of not possible cocktails

### DIFF
--- a/src/dialog_handler.py
+++ b/src/dialog_handler.py
@@ -81,6 +81,7 @@ allowed_keys = Literal[
     "cleaning_started",
     "cocktail_canceled",
     "cocktail_in_progress",
+    "cocktail_not_possible",
     "cocktail_ready_add",
     "cocktail_ready",
     "cocktailberry_up_to_date",

--- a/src/language.yaml
+++ b/src/language.yaml
@@ -67,6 +67,9 @@ dialog:
   cocktail_ready_add:
     en: 'Also add:'
     de: 'Noch hinzufügen:'
+  cocktail_not_possible:
+    en: 'Cocktail is not possible to make, not all ingredients are available!'
+    de: 'Cocktail zubereiten ist nicht möglich, nicht alle Zutaten sind verfügbar!'
   enter_cocktail_name:
     en: 'Please enter cocktail name!'
     de: 'Bitte Cocktail Namen eingeben!'


### PR DESCRIPTION
If directly called over the API, it was possible to prepare cocktails having not all ingredients available. The machine only used connected ingredients and prompted to hand add the rest. However, some of the hand adds might not be available. This is no longer possible and will return a 400.