### PR TITLE
Allow virgin only cocktail without all alcoholic ingredients

### DIFF
--- a/src/api/internal/utils.py
+++ b/src/api/internal/utils.py
@@ -28,6 +28,7 @@ def map_cocktail(cocktail: Optional[DBCocktail], scale: bool = True) -> Optional
         amount=cocktail.adjusted_amount,
         enabled=cocktail.enabled,
         virgin_available=cocktail.virgin_available,
+        only_virgin=cocktail.only_virgin,
         # ingredient hand is if it is currently not on a bottle
         ingredients=[
             CocktailIngredient(

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -39,6 +39,7 @@ class Cocktail(BaseModel):
     amount: int
     enabled: bool
     virgin_available: bool
+    only_virgin: bool
     ingredients: list[CocktailIngredient]
     image: str
     default_image: str

--- a/src/ui/cocktail_view.py
+++ b/src/ui/cocktail_view.py
@@ -46,7 +46,10 @@ def generate_image_block(cocktail: Cocktail | None, mainscreen: MainScreen):
     header_font_size = round(square_size / 15.8)
     header_height = round(square_size / 6.3)
     single_ingredient_label = UI_LANGUAGE.get_translation("label_single_ingredient", "main_window")
-    name_label = cocktail.name if cocktail is not None else single_ingredient_label
+    name_label = single_ingredient_label
+    if cocktail is not None:
+        prefix = "V. " if cocktail.only_virgin else ""
+        name_label = f"{prefix}{cocktail.name}"
     button = create_button(
         name_label,
         font_size=header_font_size,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ def db_commander():
     db_commander.insert_new_ingredient("Tequila", 38, 750, False, 100, 200, "ml")  # id 5
     # This one will not be added to the machine / available
     db_commander.insert_new_ingredient("Fanta", 0, 1000, False, 100, 50, "ml")  # id 6
+    # Adding a new alcoholic ingredient that is NOT available (neither via machine nor hand)
+    db_commander.insert_new_ingredient("Vodka", 40, 1000, False, 100, 150, "ml")  # id 7
 
     # create bottle 1-24
     with db_commander.session_scope() as session:
@@ -31,6 +33,8 @@ def db_commander():
     db_commander.insert_new_recipe("With Handadd", 20, 250, True, False, [(1, 50, 1), (4, 200, 2)])  # id 3
     # not all ingredients are available
     db_commander.insert_new_recipe("Not Available", 10, 250, True, False, [(4, 50, 1), (6, 200, 2)])  # id 4
+    # This one should be possible only in its virgin form
+    db_commander.insert_new_recipe("Virgin Only Possible", 12, 300, True, True, [(7, 100, 1), (2, 200, 2)])  # id 5
 
     # Assign ingredients to bottles
     db_commander.set_bottle_at_slot("White Rum", 1)

--- a/web_client/src/api/cocktails.ts
+++ b/web_client/src/api/cocktails.ts
@@ -38,14 +38,12 @@ export const prepareCocktail = async (
   cocktail: Cocktail,
   volume: number,
   alcohol_factor: number,
-  is_virgin: boolean,
   teamName?: string,
 ): Promise<CocktailStatus> => {
   return axiosInstance
     .post<CocktailStatus>(`${cocktail_url}/prepare/${cocktail.id}`, {
       volume,
       alcohol_factor,
-      is_virgin,
       selected_team: teamName,
     })
     .then((res) => res.data);

--- a/web_client/src/components/cocktail/CocktailList.tsx
+++ b/web_client/src/components/cocktail/CocktailList.tsx
@@ -55,6 +55,7 @@ const CocktailList: React.FC = () => {
             >
               <h2 className='text-center py-1 flex items-center justify-center'>
                 {cocktail.virgin_available && <MdNoDrinks className='mr-2' />}
+                {cocktail.only_virgin && 'V. '}
                 {cocktail.name}
               </h2>
               <div className='relative w-full' style={{ paddingTop: '100%' }}>

--- a/web_client/src/components/cocktail/CocktailSelection.tsx
+++ b/web_client/src/components/cocktail/CocktailSelection.tsx
@@ -33,7 +33,7 @@ const alcoholFactor = {
 
 const CocktailSelection: React.FC<CocktailModalProps> = ({ selectedCocktail, handleCloseModal }) => {
   const originalCocktail = JSON.parse(JSON.stringify(selectedCocktail));
-  const [alcohol, setAlcohol] = useState<alcoholState>('normal');
+  const [alcohol, setAlcohol] = useState<alcoholState>(selectedCocktail.only_virgin ? 'virgin' : 'normal');
   const [displayCocktail, setDisplayCocktail] = useState<Cocktail>(selectedCocktail);
   const [isProgressModalOpen, setIsProgressModalOpen] = useState(false);
   // Refill state
@@ -68,7 +68,7 @@ const CocktailSelection: React.FC<CocktailModalProps> = ({ selectedCocktail, han
 
   const handlePrepareCocktail = async (amount: number, teamName: string | undefined = undefined) => {
     const factor = alcoholFactor[alcohol];
-    prepareCocktail(displayCocktail, amount, factor, alcohol === 'virgin', teamName)
+    prepareCocktail(displayCocktail, amount, factor, teamName)
       .then(() => {
         setIsProgressModalOpen(true);
       })
@@ -112,13 +112,19 @@ const CocktailSelection: React.FC<CocktailModalProps> = ({ selectedCocktail, han
             <div className='flex space-x-2'>
               <button
                 onClick={() => handleAlcoholState('high')}
-                className={`w-8 p-2 rounded-full ${alcohol === 'high' ? 'bg-secondary' : 'bg-primary'}`}
+                className={`w-8 p-2 rounded-full ${alcohol === 'high' ? 'bg-secondary' : 'bg-primary'} ${
+                  selectedCocktail.only_virgin && 'disabled'
+                }`}
+                disabled={selectedCocktail.only_virgin}
               >
                 <FaSkullCrossbones className='text-background' />
               </button>
               <button
                 onClick={() => handleAlcoholState('low')}
-                className={`w-8 p-2 rounded-full ${alcohol === 'low' ? 'bg-secondary' : 'bg-primary'}`}
+                className={`w-8 p-2 rounded-full ${alcohol === 'low' ? 'bg-secondary' : 'bg-primary'} ${
+                  selectedCocktail.only_virgin && 'disabled'
+                }`}
+                disabled={selectedCocktail.only_virgin}
               >
                 <IoIosHappy className='text-background' />
               </button>
@@ -126,6 +132,7 @@ const CocktailSelection: React.FC<CocktailModalProps> = ({ selectedCocktail, han
                 <button
                   onClick={() => handleAlcoholState('virgin')}
                   className={`w-8 p-2 rounded-full ${alcohol === 'virgin' ? 'bg-secondary' : 'bg-primary'}`}
+                  disabled={selectedCocktail.only_virgin}
                 >
                   <MdNoDrinks className='text-background' />
                 </button>
@@ -136,7 +143,10 @@ const CocktailSelection: React.FC<CocktailModalProps> = ({ selectedCocktail, han
             </button>
           </div>
           <div>
-            <h2 className='text-2xl font-bold text-center text-neutral underline'>{selectedCocktail.name}</h2>
+            <h2 className='text-2xl font-bold text-center text-neutral underline'>
+              {alcohol === 'virgin' && 'V. '}
+              {selectedCocktail.name}
+            </h2>
             <div className='mt-2'>
               <ul className='text-center'>
                 {machineIngredients.map((ingredient) => (

--- a/web_client/src/index.css
+++ b/web_client/src/index.css
@@ -222,7 +222,5 @@ input[type='time']::-webkit-calendar-picker-indicator {
 /* Class added to body when modal is open */
 .ReactModal__Body--open {
   overflow: hidden;
-  position: fixed;
-  width: 100%;
-  height: 100%;
+  padding-right: var(--scrollbar-width, 15px); /* Prevent layout shift when scrollbar disappears */
 }

--- a/web_client/src/types/models.ts
+++ b/web_client/src/types/models.ts
@@ -15,6 +15,7 @@ export interface Cocktail {
   amount: number;
   enabled: boolean;
   virgin_available: boolean;
+  only_virgin: boolean;
   ingredients: CocktailIngredient[];
   image: string;
   default_image: string;


### PR DESCRIPTION
This will set cocktails as possible where all virgin ingredients meet the available state, without the need of the alcoholic counterparts for the non-virgin recipe. Alter UI that user directly sees that this is only a virgin one and makes it not possible to select the normal version in this case.

Closes https://github.com/AndreWohnsland/CocktailBerry/issues/294