### PR TITLE
fix uv sync working in old system site venv setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,12 @@ nfc = [
   "pyscard>=2.3.1",
 ]
 
+[tool.uv]
+override-dependencies = [
+    "pyqt6-qt6; sys_platform != 'linux' or python_version >= '3.12'",
+    "pyqt6; sys_platform != 'linux' or python_version >= '3.12'"
+]
+
 [tool.uv.pip]
 extra-index-url = [
     "https://pypi.python.org/simple",


### PR DESCRIPTION
Only used as a migration, if users update to v3 while still using old debian os