### PR TITLE
Make cleaning work properly with all machine configuration

### DIFF
--- a/docs/hardware-extensions/carriages.md
+++ b/docs/hardware-extensions/carriages.md
@@ -131,7 +131,7 @@ class ExtensionConfig(BaseCarriageConfig): # (4)!
         enabled: bool = False,
         home_position: int = 0,
         speed_pct_per_s: float = 10.0,
-        move_during_cleaning: bool = False,
+        move_during_cleaning: bool = True,
         wait_after_dispense: float = 0.0,
         **kwargs: Any, # (5)!
     ) -> None:

--- a/docs/hardware-extensions/dispensers.md
+++ b/docs/hardware-extensions/dispensers.md
@@ -50,6 +50,8 @@ Your `Implementation` class must inherit from `BaseDispenser` and implement thes
 | Method                                   | Required | Description                                                                                                                                        |
 | ---------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `_dispense_steps(amount_ml, pump_speed)` | **yes**  | Generator that yields consumption values. Use `try/finally` for hardware cleanup. See details below.                                               |
+| `_before_dispense(ctx)`                  | no       | Called once before dispensing starts. Override to switch direction when `ctx.revert` is `True`. Default is a no-op.                                |
+| `_after_dispense(ctx)`                   | no       | Called once after dispensing finishes (including cancellation). Override to restore direction when `ctx.revert` is `True`. Default is a no-op.     |
 | `stop()`                                 | no       | Emergency stop. Default sets the internal stop event. Override and call `super().stop()` if you need additional hardware cleanup (e.g. close pin). |
 | `cleanup()`                              | no       | Release hardware resources at shutdown. Default does nothing.                                                                                      |
 
@@ -63,11 +65,35 @@ The base class provides a concrete `dispense()` method that drives your generato
 
 1. Clears the stop event
 2. Tares the scale (if connected)
-3. Iterates your `_dispense_steps()` generator
-4. Checks for cancellation between each yield
-5. Calls progress callbacks on each yielded value
+3. Calls `_before_dispense(ctx)` (direction setup, where `ctx` is a `DispenseContext`)
+4. Iterates your `_dispense_steps()` generator
+5. Checks for cancellation between each yield
+6. Calls progress callbacks on each yielded value
+7. Calls `_after_dispense(ctx)` (direction teardown)
 
 Your generator just needs to: activate hardware, yield consumption updates in a loop, and deactivate hardware in a `finally` block. The `finally` block runs on both normal completion and cancellation (the generator is automatically closed when the stop event fires).
+
+### Per-Dispenser Reversion (Dispenser Controlled mode)
+
+When the machine is configured with `MAKER_PUMP_REVERSION_CONFIG` set to **Dispenser Controlled**, there is no global relay pin — each dispenser is responsible for reversing its own motor direction if requested during cleaning.
+
+To support this, override `_before_dispense` and `_after_dispense`. Both receive a `DispenseContext` object — currently it carries `revert: bool`, and future versions may add more fields with defaults without breaking your extension:
+
+```python
+from src.machine.dispensers.base import DispenseContext
+
+def _before_dispense(self, ctx: DispenseContext) -> None:
+    if ctx.revert:
+        # Switch motor direction, e.g. flip H-bridge pins
+        ...
+
+def _after_dispense(self, ctx: DispenseContext) -> None:
+    if ctx.revert:
+        # Restore normal direction
+        ...
+```
+
+If your dispenser does not override these hooks, it silently skips reversion — no error is raised.
 
 ## Inherited Attributes & Helpers
 
@@ -103,7 +129,7 @@ Dispenser extensions follow this lifecycle:
 1. **Discovery & variant registration** — Extensions are discovered and registered as variants of `PUMP_CONFIG` before config is read.
 2. **Config load** — The GUI can now show and edit the dispenser extension fields.
 3. **Construction** — During `init_machine()`, after the scale and carriage are created, `Implementation(slot, config, hardware)` is called once per pump slot. You receive the fully assembled `HardwareContext` (pin controller, LEDs, scale, carriage, `extra`).
-4. **Runtime use** — The scheduler calls `dispense(amount_ml, pump_speed, callback)` on each slot. The base class drives your `_dispense_steps()` generator and dispatches progress updates. `stop()` may be called from another thread to cancel.
+4. **Runtime use** — The scheduler calls `dispense(amount_ml, pump_speed, revert, callback)` on each slot. The base class builds a `DispenseContext`, calls `_before_dispense(ctx)`, drives your `_dispense_steps()` generator, dispatches progress updates, then calls `_after_dispense(ctx)`. `stop()` may be called from another thread to cancel.
 5. **`cleanup()`** — Called at shutdown to release hardware resources.
 
 ## Full Example

--- a/docs/hardware-extensions/index.md
+++ b/docs/hardware-extensions/index.md
@@ -28,9 +28,11 @@ The diagram below shows how the different extension types relate to each other a
 flowchart TD
     subgraph stage1["1. Core/Shared Hardware + LEDs"]
         pin["PinController"]
+        reverter["Reverter"]
         hw_ext["Hardware Extensions\n(addons/hardware/)"]
         leds["LEDs\n(addons/leds/)"]
         pin --> hctx
+        reverter --> hctx
         hw_ext --> hctx
         hctx["HardwareContext\ncreated"]
         hctx --> leds
@@ -69,7 +71,7 @@ flowchart TD
 
 The `HardwareContext` is built up in stages, so each component has access to everything created before it:
 
-1. **Core hardware + LEDs** — `PinController`, hardware extension instances (`extra` dict), and the `HardwareContext` itself are created first. The `LedController` singleton is then populated from `LED_CONFIG` so every later stage already sees the active LED list.
+1. **Core hardware + LEDs** — `PinController`, `Reverter`, hardware extension instances (`extra` dict), and the `HardwareContext` itself are created first. The `Reverter` receives the shared `PinController` instance directly. The `LedController` singleton is then populated from `LED_CONFIG` so every later stage already sees the active LED list.
 2. **Scale** — receives the context, so it can access pins, LEDs, and hardware extensions if needed.
 3. **Carriage** — receives the context including the scale, so it can access everything above.
 4. **RFID** — receives the context including scale and carriage; the resulting controller is also attached to the `RFIDReader()` singleton facade.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -64,16 +64,16 @@ They can be used at your own risk of CocktailBerry not working 100% properly.
 ??? info "List Hardware Config Values"
     Hardware config values are used to configure and enable the connected hardware.
 
-    | Value Name                    | Description                                                                                     |
-    | :---------------------------- | :---------------------------------------------------------------------------------------------- |
-    | `MAKER_PINS_INVERTED`         | [Inverts](faq.md#what-is-the-inverted-option) pin signal (on=low, off=high)                     |
-    | `PUMP_CONFIG`                 | Config for each pump: type, pin, volume flow, tube volume, estimation method, carriage position |
-    | `I2C_CONFIG`                  | Config for I2C GPIO expander (16 pins, 0-15)                                                    |
-    | `LED_CONFIG`                  | List of LED configs (discriminated by `led_type`: Normal or WSLED)                              |
+    | Value Name                    | Description                                                                                                    |
+    | :---------------------------- | :------------------------------------------------------------------------------------------------------------- |
+    | `MAKER_PINS_INVERTED`         | [Inverts](faq.md#what-is-the-inverted-option) pin signal (on=low, off=high)                                    |
+    | `PUMP_CONFIG`                 | Config for each pump: type, pin, volume flow, tube volume, estimation method, carriage position                |
+    | `I2C_CONFIG`                  | Config for I2C GPIO expander (16 pins, 0-15)                                                                   |
+    | `LED_CONFIG`                  | List of LED configs (discriminated by `led_type`: Normal or WSLED)                                             |
     | `RFID_CONFIG`                 | RFID/NFC reader configuration: driver type, enable/disable, [more info](troubleshooting.md#set-up-rfid-reader) |
-    | `MAKER_PUMP_REVERSION_CONFIG` | Enables reversion (direction) of pump during cleaning                                           |
-    | `SCALE_CONFIG`                | Scale hardware configuration: driver type, enable/disable and calibration factor                |
-    | `CARRIAGE_CONFIG`             | Carriage/slide configuration: enable/disable, home position, speed and cleaning behavior        |
+    | `MAKER_PUMP_REVERSION_CONFIG` | Enables reversion (direction) of pump during cleaning                                                          |
+    | `SCALE_CONFIG`                | Scale hardware configuration: driver type, enable/disable and calibration factor                               |
+    | `CARRIAGE_CONFIG`             | Carriage/slide configuration: enable/disable, home position, speed and cleaning behavior                       |
 
 ??? info "List Software Config Values"
     Software config values are used to configure additional connected software and its behavior.
@@ -83,7 +83,7 @@ They can be used at your own risk of CocktailBerry not working 100% properly.
     | `MICROSERVICE_ACTIVE`          | Post to microservice set up by docker                      |
     | `MICROSERVICE_BASE_URL`        | Base URL for microservice (default: http://127.0.0.1:5000) |
     | `TEAMS_ACTIVE`                 | Use teams feature                                          |
-    | `TEAM_BUTTON_NAMES`            | List of format ["Team1", "Team2"]                          |
+    | `TEAM_BUTTON_NAMES`            | List of format \["Team1", "Team2"\]                        |
     | `TEAM_API_URL`                 | Endpoint of teams API, default used port by API is 8080    |
     | `WAITER_MODE`                  | Enable or disable Service Personnel Mode                   |
     | `WAITER_LOGOUT_AFTER_COCKTAIL` | Log out after cocktail preparation                         |

--- a/src/api/routers/options.py
+++ b/src/api/routers/options.py
@@ -108,7 +108,7 @@ async def clean_machine(background_tasks: BackgroundTasks, revert_pumps: bool = 
     raise_when_cocktail_is_in_progress()
     _logger.info("Cleaning started by user request")
     # Reversion only honored when machine is configured for it; ignore the flag otherwise.
-    use_revert = revert_pumps and cfg.MAKER_PUMP_REVERSION_CONFIG.use_reversion
+    use_revert = revert_pumps and cfg.MAKER_PUMP_REVERSION_CONFIG.enabled
     mc = MachineController()
     background_tasks.add_task(mc.clean_pumps, None, use_revert)
     return ApiMessage(message=DH.get_translation("cleaning_started"))

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -106,7 +106,7 @@ SHARED_CARRIAGE_FIELDS: dict[str, ConfigInterface[Any]] = {
     "enabled": BoolType(check_name="Enabled"),
     "home_position": IntType([build_number_limiter(0, 100)], prefix="pos:", suffix="%"),
     "speed_pct_per_s": FloatType([build_number_limiter(0.1, 100)], suffix="%/s"),
-    "move_during_cleaning": BoolType(check_name="Move During Cleaning"),
+    "move_during_cleaning": BoolType(check_name="Move During Cleaning", default=True),
     "wait_after_dispense": FloatType([build_number_limiter(0, 30)], suffix="s"),
 }
 

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -34,14 +34,15 @@ from src.config.config_types import (
     DCPumpConfig,
     DictType,
     DiscriminatedDictType,
+    DispenserControlledReversionConfig,
     FloatType,
+    GlobalReversionConfig,
     HX711ScaleConfig,
     I2CExpanderConfig,
     IntType,
     ListType,
     NAU7802ScaleConfig,
     NormalLedConfig,
-    ReversionConfig,
     StepperPumpConfig,
     StringType,
     WS281xLedConfig,
@@ -89,7 +90,7 @@ SHARED_PUMP_FIELDS: dict[str, ConfigInterface[Any]] = {
     "volume_flow": FloatType([build_number_limiter(0.1, 1000)], suffix="ml/s"),
     "tube_volume": IntType([build_number_limiter(0, 100)], suffix="ml"),
     "consumption_estimation": ChooseOptions.consumption_estimation,
-    "carriage_position": IntType([build_number_limiter(0, 100)], suffix="pos"),
+    "carriage_position": IntType([build_number_limiter(0, 100)], prefix="pos:", suffix="%"),
 }
 
 SHARED_SCALE_FIELDS: dict[str, ConfigInterface[Any]] = {
@@ -103,7 +104,7 @@ SHARED_SCALE_FIELDS: dict[str, ConfigInterface[Any]] = {
 SHARED_CARRIAGE_FIELDS: dict[str, ConfigInterface[Any]] = {
     "carriage_type": ChooseOptions.carriage_type,
     "enabled": BoolType(check_name="Enabled"),
-    "home_position": IntType([build_number_limiter(0, 100)], suffix="pos"),
+    "home_position": IntType([build_number_limiter(0, 100)], prefix="pos:", suffix="%"),
     "speed_pct_per_s": FloatType([build_number_limiter(0.1, 100)], suffix="%/s"),
     "move_during_cleaning": BoolType(check_name="Move During Cleaning"),
     "wait_after_dispense": FloatType([build_number_limiter(0, 30)], suffix="s"),
@@ -118,6 +119,11 @@ SHARED_LED_FIELDS: dict[str, ConfigInterface[Any]] = {
     "led_type": ChooseOptions.led_driver,
     "default_on": BoolType(check_name="Default On"),
     "preparation_state": ChooseOptions.leds,
+}
+
+SHARED_REVERSION_FIELDS: dict[str, ConfigInterface[Any]] = {
+    "reversion_type": ChooseOptions.reversion_type,
+    "enabled": BoolType(check_name="Enabled", default=False),
 }
 
 
@@ -163,7 +169,9 @@ class ConfigManager:
     # Base multiplier for alcohol in the recipe
     MAKER_ALCOHOL_FACTOR: int = 100
     # Reversion for cleaning
-    MAKER_PUMP_REVERSION_CONFIG = ReversionConfig(use_reversion=False, pin=0, pin_type="GPIO", inverted=False)
+    MAKER_PUMP_REVERSION_CONFIG = GlobalReversionConfig(
+        enabled=False, pin=0, pin_type="GPIO", board_number=1, inverted=False
+    )
     # If the maker should check automatically for updates
     MAKER_SEARCH_UPDATES: bool = True
     # If the maker should check if there is enough in the bottle before making a cocktail
@@ -303,15 +311,27 @@ class ConfigManager:
             "MAKER_SIMULTANEOUSLY_PUMPS": IntType([build_number_limiter(1, 999)]),
             "MAKER_CLEAN_TIME": IntType([build_number_limiter()], suffix="s"),
             "MAKER_ALCOHOL_FACTOR": IntType([build_number_limiter(10, 200)], suffix="%"),
-            "MAKER_PUMP_REVERSION_CONFIG": DictType(
+            "MAKER_PUMP_REVERSION_CONFIG": DiscriminatedDictType(
+                "reversion_type",
                 {
-                    "use_reversion": BoolType(check_name="active", default=False),
-                    "pin_type": ChooseOptions.pin,
-                    "board_number": IntType([build_number_limiter(1, 99)], prefix="#", default=1),
-                    "pin": IntType([build_number_limiter(0)], default=0, prefix="Pin:"),
-                    "inverted": BoolType(check_name="Inverted", default=False),
+                    "Global": DictType(
+                        {
+                            **SHARED_REVERSION_FIELDS,
+                            "pin_type": ChooseOptions.pin,
+                            "board_number": IntType([build_number_limiter(1, 99)], prefix="#", default=1),
+                            "pin": IntType([build_number_limiter(0)], default=0, prefix="Pin:"),
+                            "inverted": BoolType(check_name="Inverted", default=False),
+                        },
+                        GlobalReversionConfig,
+                    ),
+                    "Dispenser Controlled": DictType(
+                        {
+                            **SHARED_REVERSION_FIELDS,
+                        },
+                        DispenserControlledReversionConfig,
+                    ),
                 },
-                ReversionConfig,
+                default_variant="Global",
             ),
             "MAKER_SEARCH_UPDATES": BoolType(check_name="Search for Updates"),
             "MAKER_CHECK_BOTTLE": BoolType(check_name="Check Bottle Volume"),

--- a/src/config/config_types.py
+++ b/src/config/config_types.py
@@ -159,6 +159,7 @@ class ChooseOptions:
     scale_driver = ChooseType(allowed=SUPPORTED_SCALE_DRIVERS, default="HX711")
     carriage_type = ChooseType(allowed=SUPPORTED_CARRIAGE_TYPES, default="NoCarriage")
     led_driver = ChooseType(allowed=SUPPORTED_LED_DRIVERS, default="Normal")
+    reversion_type = ChooseType(allowed=["Global", "Dispenser Controlled"], default="Global")
 
 
 class StringType(_ConfigType[str]):
@@ -683,18 +684,34 @@ class I2CExpanderConfig(ConfigClass):
 
     def to_config(self) -> dict[str, bool | int | str]:
         return {
+            "enabled": self.enabled,
             "device_type": self.device_type,
             "board_number": self.board_number,
-            "enabled": self.enabled,
             "address": self.address,
             "inverted": self.inverted,
         }
 
 
-class ReversionConfig(ConfigClass):
-    """Configuration for pump reversion."""
+class BaseReversionConfig(ConfigClass):
+    """Shared base config for all reversion variants."""
 
-    use_reversion: bool
+    reversion_type: str
+    enabled: bool
+
+    def __init__(self, reversion_type: str, enabled: bool = False, **kwargs: Any) -> None:
+        self.reversion_type = reversion_type
+        self.enabled = enabled
+
+    def to_config(self) -> dict[str, Any]:
+        return {
+            "reversion_type": self.reversion_type,
+            "enabled": self.enabled,
+        }
+
+
+class GlobalReversionConfig(BaseReversionConfig):
+    """Configuration for global (single shared pin) pump reversion."""
+
     pin: int
     inverted: bool
     pin_type: SupportedPinControlType
@@ -702,13 +719,15 @@ class ReversionConfig(ConfigClass):
 
     def __init__(
         self,
-        use_reversion: bool,
-        pin: int,
-        inverted: bool,
+        enabled: bool = False,
+        pin: int = 0,
+        inverted: bool = False,
         pin_type: SupportedPinControlType = "GPIO",
         board_number: int = 1,
+        reversion_type: str = "Global",
+        **kwargs: Any,
     ) -> None:
-        self.use_reversion = use_reversion
+        super().__init__(reversion_type=reversion_type, enabled=enabled)
         self.pin = pin
         self.pin_type = pin_type
         self.inverted = inverted
@@ -720,13 +739,32 @@ class ReversionConfig(ConfigClass):
         return PinId(self.pin_type, self.board_number, self.pin)
 
     def to_config(self) -> dict[str, Any]:
-        return {
-            "pin_type": self.pin_type,
-            "board_number": self.board_number,
-            "pin": self.pin,
-            "use_reversion": self.use_reversion,
-            "inverted": self.inverted,
-        }
+        config = super().to_config()
+        config.update(
+            {
+                "pin_type": self.pin_type,
+                "board_number": self.board_number,
+                "pin": self.pin,
+                "inverted": self.inverted,
+            }
+        )
+        return config
+
+
+class DispenserControlledReversionConfig(BaseReversionConfig):
+    """Configuration for per-dispenser reversion.
+
+    When active, each dispenser is expected to implement direction control itself.
+    If a dispenser does not support reversion, it will silently skip it.
+    """
+
+    def __init__(
+        self,
+        active: bool = False,
+        reversion_type: str = "Dispenser Controlled",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(reversion_type=reversion_type, enabled=active)
 
 
 class BaseLedConfig(ConfigClass):

--- a/src/config/config_types.py
+++ b/src/config/config_types.py
@@ -760,11 +760,11 @@ class DispenserControlledReversionConfig(BaseReversionConfig):
 
     def __init__(
         self,
-        active: bool = False,
+        enabled: bool = False,
         reversion_type: str = "Dispenser Controlled",
         **kwargs: Any,
     ) -> None:
-        super().__init__(reversion_type=reversion_type, enabled=active)
+        super().__init__(reversion_type=reversion_type, enabled=enabled)
 
 
 class BaseLedConfig(ConfigClass):

--- a/src/config/config_types.py
+++ b/src/config/config_types.py
@@ -916,7 +916,7 @@ class BaseCarriageConfig(ConfigClass):
         enabled: bool = False,
         home_position: int = 0,
         speed_pct_per_s: float = 10.0,
-        move_during_cleaning: bool = False,
+        move_during_cleaning: bool = True,
         wait_after_dispense: float = 0.0,
         **kwargs: Any,
     ) -> None:

--- a/src/language.yaml
+++ b/src/language.yaml
@@ -1006,9 +1006,9 @@ ui:
       de: 'Skalierungsfaktor für alkoholische Zutaten in jedem Rezept. Verwende diesen, um den Alkoholgehalt aller Cocktails zu verringern/erhöhen. Standard ist 100%'
       pl: 'Wartość skalująca składniki alkoholowe w każdym przepisie. Użyj tego do zmniejszenia/zwiększenia poziomu alkoholu we wszystkich koktajlach. Domyślnie 100%'
     MAKER_PUMP_REVERSION_CONFIG:
-      en: 'Configuration for pump reversion: pin type, board number (# only relevant for I2C), pin and signal inversion. Needed for some setups to be able to revert the pump direction.'
-      de: 'Konfiguration für Pumpen Umkehrung: Pin-Typ, Board-Nummer (# nur relevant für I2C), Pin und Signalinvertierung. Benötigt von einigen Setups, um die Pumpenrichtung ändern zu können.'
-      pl: 'Konfiguracja zmiany kierunku pompy: typ pinu, numer płytki (# tylko dla I2C), pin oraz inwersja sygnału. Wymagana w niektórych konfiguracjach do zmiany kierunku pompy.'
+      en: 'Configuration for pump reversion. Select "Global" for a shared relay pin (specify pin type, board number, pin, and signal inversion) or "Dispenser Controlled" to let each dispenser handle its own direction — dispensers that do not support reversion will skip it. Activate to enable reversion during cleaning.'
+      de: 'Konfiguration für Pumpen Umkehrung. Wähle "Global" für einen gemeinsamen Relais-Pin (Pin-Typ, Board-Nummer, Pin und Signalinvertierung angeben) oder "Dispenser Controlled", damit jeder Dispenser die Richtung selbst steuert — Dispenser ohne Unterstützung überspringen die Umkehrung. Aktivieren, um die Umkehrung beim Reinigen zu nutzen.'
+      pl: 'Konfiguracja zmiany kierunku pompy. Wybierz "Global" dla wspólnego pinu przekaźnika (podaj typ pinu, numer płytki, pin i inwersję sygnału) lub "Dispenser Controlled", aby każdy dozownik sam kontrolował kierunek — dozowniki bez obsługi pominią odwracanie. Aktywuj, aby włączyć odwracanie podczas czyszczenia.'
     MAKER_SEARCH_UPDATES:
       en: 'Search for updates, if available internet connection'
       de: 'Sucht nach Updates, wenn Internetverbindung besteht'

--- a/src/machine/controller.py
+++ b/src/machine/controller.py
@@ -16,11 +16,11 @@ from src.database_commander import DatabaseCommander
 from src.machine.carriage import create_carriage
 from src.machine.dispensers import create_dispenser
 from src.machine.dispensers.base import BaseDispenser
-from src.machine.dispensers.scheduler import DispenserScheduler, PreparationItem
+from src.machine.dispensers.scheduler import CleaningItem, CleaningScheduler, DispenserScheduler, PreparationItem
 from src.machine.hardware import HardwareContext
 from src.machine.leds import LedController, create_led_controller
 from src.machine.pin_controller import PinController
-from src.machine.reverter import Reverter
+from src.machine.reverter import create_reverter
 from src.machine.rfid import RFIDReader, create_rfid
 from src.machine.scale import create_scale
 from src.models import CocktailStatus, EventType, Ingredient, PreparationResult, PrepareResult
@@ -52,9 +52,11 @@ class MachineController:
     def init_machine(self) -> None:
         _logger.log_header("INFO", "Initializing machine")
         # Stage 1: core hardware + extensions (no dependencies)
+        pin_controller = PinController()
         self.hardware = HardwareContext(
-            pin_controller=PinController(),
+            pin_controller=pin_controller,
             led_controller=LedController(),
+            reverter=create_reverter(cfg.MAKER_PUMP_REVERSION_CONFIG, pin_controller),
             extra=HARDWARE_ADDONS.create_all(),
         )
         # Stage 1b: populate the LED controller singleton from cfg.LED_CONFIG.
@@ -70,7 +72,6 @@ class MachineController:
         # Stage 4: RFID can access pins, leds, extra, scale, AND carriage
         self.hardware.rfid = create_rfid(cfg.RFID_CONFIG, self.hardware)
         RFIDReader().attach(self.hardware.rfid)
-        self.reverter = Reverter(cfg.MAKER_PUMP_REVERSION_CONFIG)
         self.set_up_pumps()
         self.default_led()
         _logger.log_header("INFO", "Machine initialized")
@@ -84,15 +85,27 @@ class MachineController:
         pin flips all pumps, so disallowed slots cannot run forward in parallel).
         """
         shared.cocktail_status = CocktailStatus(0, status=PrepareResult.IN_PROGRESS)
-        items = self._build_clean_items(revert=revert_pumps)
+        items = self._build_cleaning_items(revert=revert_pumps)
         if w is not None:
             w.open_progression_window("Cleaning")
         _logger.log_header("INFO", "Start Cleaning")
-        if revert_pumps:
-            self.reverter.revert_on()
-        self._run_scheduler(w, items, use_carriage=cfg.CARRIAGE_CONFIG.move_during_cleaning)
-        if revert_pumps:
-            self.reverter.revert_off()
+        if revert_pumps and self.hardware.reverter is not None:
+            self.hardware.reverter.revert_on()
+        carriage = self.hardware.carriage if cfg.CARRIAGE_CONFIG.move_during_cleaning else None
+        scheduler = CleaningScheduler(cfg.MAKER_SIMULTANEOUSLY_PUMPS, carriage=carriage)
+
+        def on_progress(progress: int, _: list[float]) -> None:
+            shared.cocktail_status.progress = progress
+            if w is not None:
+                w.change_progression_window(progress)
+                QApplication.processEvents()
+
+        def is_cancelled() -> bool:
+            return shared.cocktail_status.status == PrepareResult.CANCELED
+
+        scheduler.run(items, on_progress, is_cancelled)
+        if revert_pumps and self.hardware.reverter is not None:
+            self.hardware.reverter.revert_off()
         _logger.log_header("INFO", "Done Cleaning")
         if w is not None:
             w.close_progression_window()
@@ -148,12 +161,10 @@ class MachineController:
     ) -> None:
         """Create a scheduler and run the given items."""
         carriage = self.hardware.carriage if use_carriage else None
-        home_position = cfg.CARRIAGE_CONFIG.home_position if carriage is not None else 0
         scheduler = DispenserScheduler(
             cfg.MAKER_SIMULTANEOUSLY_PUMPS,
             verbose=verbose,
             carriage=carriage,
-            home_position=home_position,
         )
 
         def on_progress(progress: int, consumption: list[float]) -> None:
@@ -175,7 +186,8 @@ class MachineController:
         for slot, pump_cfg in enumerate(used_config, start=1):
             dispenser = create_dispenser(slot, pump_cfg, self.hardware)
             self.dispensers[slot] = dispenser
-        self.reverter.initialize_pin()
+        if self.hardware.reverter is not None:
+            self.hardware.reverter.initialize_pin()
 
     def close_all_pumps(self) -> None:
         """Stop all active dispensers."""
@@ -188,7 +200,7 @@ class MachineController:
         HARDWARE_ADDONS.cleanup_all()
         self.hardware.cleanup()
 
-    def _build_clean_items(self, revert: bool = False) -> list[PreparationItem]:
+    def _build_cleaning_items(self, revert: bool = False) -> list[CleaningItem]:
         """Build cleaning items for all active dispensers.
 
         When revert is True, slots whose ingredient is flagged as
@@ -204,12 +216,11 @@ class MachineController:
         for slot, dispenser in self.dispensers.items():
             if slot in skip_slots:
                 continue
-            amount_ml = dispenser.volume_flow * cfg.MAKER_CLEAN_TIME
             items.append(
-                PreparationItem(
+                CleaningItem(
                     dispenser=dispenser,
-                    amount_ml=amount_ml,
-                    pump_speed=100,
+                    duration_seconds=cfg.MAKER_CLEAN_TIME,
+                    revert=revert,
                 )
             )
         return items

--- a/src/machine/controller.py
+++ b/src/machine/controller.py
@@ -118,7 +118,6 @@ class MachineController:
         ingredient_list: list[Ingredient],
         recipe: str = "",
         is_cocktail: bool = True,
-        verbose: bool = True,
         finish_message: str = "",
     ) -> PreparationResult:
         """RPI Logic to prepare the cocktail.
@@ -133,7 +132,7 @@ class MachineController:
         _logger.log_header("INFO", f"Starting {recipe}")
         if is_cocktail:
             self.hardware.led_controller.preparation_start()
-        self._run_scheduler(w, items, verbose=verbose, use_carriage=True)
+        self._run_scheduler(w, items, use_carriage=True)
         if is_cocktail:
             self.hardware.led_controller.preparation_end()
         # Write consumption back to ingredient objects
@@ -156,14 +155,12 @@ class MachineController:
         self,
         w: MainScreen | None,
         items: list[PreparationItem],
-        verbose: bool = True,
         use_carriage: bool = False,
     ) -> None:
         """Create a scheduler and run the given items."""
         carriage = self.hardware.carriage if use_carriage else None
         scheduler = DispenserScheduler(
             cfg.MAKER_SIMULTANEOUSLY_PUMPS,
-            verbose=verbose,
             carriage=carriage,
         )
 

--- a/src/machine/dispensers/base.py
+++ b/src/machine/dispensers/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator
+from dataclasses import dataclass
 from threading import Event
 from typing import TYPE_CHECKING
 
@@ -11,6 +12,18 @@ if TYPE_CHECKING:
 
 ProgressCallback = Callable[[float, bool], None]
 """Callback signature: (consumption_ml, is_done) -> None"""
+
+
+@dataclass
+class DispenseContext:
+    """Contextual information passed to dispenser hooks.
+
+    Passed to ``_before_dispense`` and ``_after_dispense``. New fields
+    added here with defaults will never break existing extension code.
+    """
+
+    revert: bool
+    """Whether this dispense run should reverse the motor direction."""
 
 
 class BaseDispenser(ABC):
@@ -41,7 +54,10 @@ class BaseDispenser(ABC):
         """True when this dispenser requires exclusive scheduling (i.e. it uses a scale)."""
         return self._scale is not None
 
-    def dispense(self, amount_ml: float, pump_speed: int, callback: ProgressCallback) -> float:
+    def _before_dispense(self, ctx: DispenseContext) -> None: ...  # noop
+    def _after_dispense(self, ctx: DispenseContext) -> None: ...  # noop
+
+    def dispense(self, amount_ml: float, pump_speed: int, revert: bool, callback: ProgressCallback) -> float:
         """Dispense the given amount at the given pump speed.
 
         This is a template method that drives ``_dispense_steps()``.
@@ -56,12 +72,15 @@ class BaseDispenser(ABC):
         if self._scale is not None:
             self._scale.tare()
         consumption = 0.0
+        ctx = DispenseContext(revert=revert)
+        self._before_dispense(ctx)
         callback(consumption, False)
         for consumption in self._dispense_steps(amount_ml, pump_speed):
             if self._stop_event.is_set():
                 break
             callback(consumption, False)
         callback(consumption, True)
+        self._after_dispense(ctx)
         return consumption
 
     @abstractmethod

--- a/src/machine/dispensers/scheduler.py
+++ b/src/machine/dispensers/scheduler.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import contextlib
 import heapq
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -36,6 +37,7 @@ class PreparationItem:
     recipe_order: int = 1
     ingredient: Ingredient | None = None
     """Back-reference to the source ingredient. None for non-ingredient tasks like cleaning."""
+    revert: bool = False
 
     def __post_init__(self) -> None:
         if self.estimated_time <= 0.0:
@@ -43,6 +45,15 @@ class PreparationItem:
             if divisor == 0:
                 return
             self.estimated_time = self.amount_ml / divisor
+
+
+@dataclass
+class CleaningItem:
+    """A single time-based cleaning task for the CleaningScheduler."""
+
+    dispenser: BaseDispenser
+    duration_seconds: float
+    revert: bool = False
 
 
 class DispenserScheduler:
@@ -60,12 +71,10 @@ class DispenserScheduler:
         max_concurrent: int,
         verbose: bool = True,
         carriage: CarriageInterface | None = None,
-        home_position: int = 0,
     ) -> None:
         self.max_concurrent = max_concurrent
         self.verbose = verbose
         self._carriage = carriage
-        self._home_position = home_position
         self._next_log_time = 0.0
 
     def run(
@@ -84,8 +93,8 @@ class DispenserScheduler:
         self._next_log_time = 0.0
         groups = _group_by_recipe_order(items)
         if self._carriage is not None:
-            groups = [_order_by_carriage_position(g, self._home_position) for g in groups]
-            max_time = _estimate_carriage_time(groups, self._carriage, self._home_position)
+            groups = [_order_by_carriage_position(g, self._carriage.home_position) for g in groups]
+            max_time = _estimate_carriage_time(groups, self._carriage, self._carriage.home_position)
         else:
             max_time = _estimate_total_time(groups, self.max_concurrent)
         if max_time == 0:
@@ -201,7 +210,12 @@ class DispenserScheduler:
             self._emit_progress(all_items, on_progress)
 
         try:
-            consumption = item.dispenser.dispense(item.amount_ml, item.pump_speed, progress_callback)
+            consumption = item.dispenser.dispense(
+                amount_ml=item.amount_ml,
+                pump_speed=item.pump_speed,
+                revert=item.revert,
+                callback=progress_callback,
+            )
             item.consumption = consumption
             item.done = True
         except Exception:
@@ -229,6 +243,7 @@ class DispenserScheduler:
         _logger.debug(f"{progress:>2}% | Volumes: {pretty}")
 
 
+# TODO: this heavily overlaps with _run_exclusive ->> do we need _run_exclusive or can we merge this?
 def _run_dispenser(data: PreparationItem) -> float:
     """Run a single dispenser. Called in a worker thread."""
 
@@ -236,7 +251,12 @@ def _run_dispenser(data: PreparationItem) -> float:
         data.consumption = consumption_ml
         data.done = is_done
 
-    consumption = data.dispenser.dispense(data.amount_ml, data.pump_speed, callback)
+    consumption = data.dispenser.dispense(
+        amount_ml=data.amount_ml,
+        pump_speed=data.pump_speed,
+        revert=data.revert,
+        callback=callback,
+    )
     data.consumption = consumption
     data.done = True
     return consumption
@@ -301,7 +321,9 @@ def _estimate_carriage_time(
     return round(total, 2)
 
 
-def _order_by_carriage_position(items: list[PreparationItem], home_position: int) -> list[PreparationItem]:
+def _order_by_carriage_position[DispatchItem: (PreparationItem, CleaningItem)](
+    items: list[DispatchItem], home_position: int
+) -> list[DispatchItem]:
     """Order items to minimize total carriage travel distance.
 
     Since positions are on a 1D line (0-100), the optimal order is a monotonic
@@ -318,7 +340,7 @@ def _order_by_carriage_position(items: list[PreparationItem], home_position: int
     return descending
 
 
-def _total_travel(items: list[PreparationItem], home_position: int) -> int:
+def _total_travel(items: Sequence[PreparationItem | CleaningItem], home_position: int) -> int:
     """Calculate total carriage travel: home -> items in order -> home."""
     if not items:
         return 0
@@ -328,3 +350,124 @@ def _total_travel(items: list[PreparationItem], home_position: int) -> int:
         total += abs(positions[i] - positions[i - 1])
     total += abs(positions[-1] - home_position)
     return total
+
+
+# ---------------------------------------------------------------------------
+# Cleaning scheduler — time-based, no volume/scale logic
+# ---------------------------------------------------------------------------
+
+_CLEANING_LARGE_AMOUNT = 2000
+"""Sentinel amount that ensures a dispenser never self-terminates during cleaning.
+
+The scheduler is responsible for stopping dispensers after the configured
+wall-clock duration, so the amount passed to dispense() must never be
+reached naturally.
+"""
+
+_CLEANING_POLL_INTERVAL = 0.05
+"""How often (seconds) the cleaning loop checks elapsed time and cancellation."""
+
+
+class CleaningScheduler:
+    """Schedules time-based pump cleaning.
+
+    Each dispenser runs for a fixed wall-clock duration — no volume
+    calculations or scale interaction. In parallel mode, items are
+    processed in batches of up to *max_concurrent*. With a carriage,
+    items run sequentially with position moves between each.
+    """
+
+    def __init__(
+        self,
+        max_concurrent: int,
+        carriage: CarriageInterface | None = None,
+    ) -> None:
+        self.max_concurrent = max_concurrent
+        self._carriage = carriage
+
+    def run(
+        self,
+        items: list[CleaningItem],
+        on_progress: SchedulerProgressCallback,
+        is_cancelled: CancelCheck,
+    ) -> None:
+        """Execute all cleaning items."""
+        if not items:
+            return
+        if self._carriage is not None:
+            self._run_with_carriage(items, on_progress, is_cancelled)
+            self._carriage.home()
+        else:
+            self._run_parallel(items, on_progress, is_cancelled)
+
+    def _run_parallel(
+        self,
+        items: list[CleaningItem],
+        on_progress: SchedulerProgressCallback,
+        is_cancelled: CancelCheck,
+    ) -> None:
+        """Run items in parallel batches, emitting overall progress."""
+        batches = [items[i : i + self.max_concurrent] for i in range(0, len(items), self.max_concurrent)]
+        n_batches = len(batches)
+        for batch_idx, batch in enumerate(batches):
+            if is_cancelled():
+                break
+            base = batch_idx * 100 // n_batches
+            ceiling = (batch_idx + 1) * 100 // n_batches
+            self._run_timed(batch, on_progress, is_cancelled, base_progress=base, max_progress=ceiling)
+
+    def _run_with_carriage(
+        self,
+        items: list[CleaningItem],
+        on_progress: SchedulerProgressCallback,
+        is_cancelled: CancelCheck,
+    ) -> None:
+        """Run items sequentially with carriage positioning before each."""
+        if self._carriage is None:
+            raise ValueError("Carriage is required for this operation")
+        ordered = _order_by_carriage_position(items, self._carriage.home_position)
+        total = len(ordered)
+        for idx, item in enumerate(ordered):
+            if is_cancelled():
+                break
+            self._carriage.move_to(item.dispenser.carriage_position)
+            base = idx * 100 // total
+            ceiling = (idx + 1) * 100 // total
+            self._run_timed([item], on_progress, is_cancelled, base_progress=base, max_progress=ceiling)
+            if self._carriage.wait_after_dispense > 0 and not is_cancelled():
+                time.sleep(self._carriage.wait_after_dispense)
+
+    def _run_timed(
+        self,
+        batch: list[CleaningItem],
+        on_progress: SchedulerProgressCallback,
+        is_cancelled: CancelCheck,
+        base_progress: int,
+        max_progress: int,
+    ) -> None:
+        """Start all dispensers in *batch*, wait for duration, then stop all.
+
+        Uses a sentinel large amount so dispensers never self-terminate —
+        the scheduler drives the stop after the wall-clock duration elapses.
+        """
+        duration = batch[0].duration_seconds
+        with ThreadPoolExecutor(max_workers=len(batch)) as executor:
+            futures = [
+                executor.submit(item.dispenser.dispense, _CLEANING_LARGE_AMOUNT, 100, item.revert, lambda *_: None)
+                for item in batch
+            ]
+            start = time.perf_counter()
+            while True:
+                elapsed = time.perf_counter() - start
+                if elapsed >= duration or is_cancelled():
+                    for item in batch:
+                        item.dispenser.stop()
+                    break
+                fraction = elapsed / duration
+                on_progress(base_progress + int(fraction * (max_progress - base_progress)), [])
+                time.sleep(_CLEANING_POLL_INTERVAL)
+            for f in futures:
+                with contextlib.suppress(Exception):
+                    f.result(timeout=2.0)
+        if not is_cancelled():
+            on_progress(max_progress, [])

--- a/src/machine/dispensers/scheduler.py
+++ b/src/machine/dispensers/scheduler.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import heapq
 import time
 from collections.abc import Callable, Sequence
@@ -22,6 +21,12 @@ SchedulerProgressCallback = Callable[[int, list[float]], None]
 
 CancelCheck = Callable[[], bool]
 """Returns True if the preparation should be cancelled."""
+
+_POLL_INTERVAL = 0.05
+"""How often (seconds) the schedulers' inner loops check elapsed time and cancellation."""
+
+_PROGRESS_COMPLETE = 100
+"""Maximum progress value emitted via on_progress callbacks (100 = done)."""
 
 
 @dataclass
@@ -56,7 +61,45 @@ class CleaningItem:
     revert: bool = False
 
 
-class DispenserScheduler:
+CarriageItem = PreparationItem | CleaningItem
+"""Either kind of scheduler item — both expose ``dispenser.carriage_position``."""
+
+CarriageRunOne = Callable[[CarriageItem, int, int], None]
+"""``(item, index, total) -> None`` callback invoked once per carriage-positioned item."""
+
+
+class BaseScheduler:
+    """Shared infrastructure for both schedulers.
+
+    Owns the constructor and the carriage-sequence template method
+    (``move_to → on_each → sleep wait_after_dispense``). Does NOT call
+    ``home()`` — each subclass's ``run()`` owns when to home.
+    """
+
+    def __init__(self, max_concurrent: int, carriage: CarriageInterface | None = None) -> None:
+        self.max_concurrent = max_concurrent
+        self._carriage = carriage
+
+    def _run_carriage_sequence(
+        self,
+        ordered_items: Sequence[CarriageItem],
+        on_each: CarriageRunOne,
+        is_cancelled: CancelCheck,
+    ) -> None:
+        """Iterate carriage-positioned items: move → on_each(item, idx, total) → wait."""
+        if self._carriage is None:
+            raise ValueError("Carriage is required for this operation")
+        total = len(ordered_items)
+        for idx, item in enumerate(ordered_items):
+            if is_cancelled():
+                break
+            self._carriage.move_to(item.dispenser.carriage_position)
+            on_each(item, idx, total)
+            if self._carriage.wait_after_dispense > 0 and not is_cancelled():
+                time.sleep(self._carriage.wait_after_dispense)
+
+
+class DispenserScheduler(BaseScheduler):
     """Schedules and runs dispenser tasks with greedy slot-filling.
 
     Responsibilities:
@@ -66,15 +109,8 @@ class DispenserScheduler:
     - Manages threading, progress aggregation, and cancellation
     """
 
-    def __init__(
-        self,
-        max_concurrent: int,
-        verbose: bool = True,
-        carriage: CarriageInterface | None = None,
-    ) -> None:
-        self.max_concurrent = max_concurrent
-        self.verbose = verbose
-        self._carriage = carriage
+    def __init__(self, max_concurrent: int, carriage: CarriageInterface | None = None) -> None:
+        super().__init__(max_concurrent, carriage)
         self._next_log_time = 0.0
 
     def run(
@@ -82,25 +118,15 @@ class DispenserScheduler:
         items: list[PreparationItem],
         on_progress: SchedulerProgressCallback,
         is_cancelled: CancelCheck,
-    ) -> tuple[float, float]:
-        """Execute all preparation items respecting scheduling constraints.
-
-        Returns (actual_elapsed_time, estimated_max_time).
-        """
+    ) -> None:
+        """Execute all preparation items respecting scheduling constraints."""
         if not items:
-            return 0.0, 0.0
+            return
 
         self._next_log_time = 0.0
         groups = _group_by_recipe_order(items)
         if self._carriage is not None:
             groups = [_order_by_carriage_position(g, self._carriage.home_position) for g in groups]
-            max_time = _estimate_carriage_time(groups, self._carriage, self._carriage.home_position)
-        else:
-            max_time = _estimate_total_time(groups, self.max_concurrent)
-        if max_time == 0:
-            return 0.0, 0.0
-
-        start_time = time.perf_counter()
 
         for group in groups:
             if is_cancelled():
@@ -112,9 +138,6 @@ class DispenserScheduler:
 
         if self._carriage is not None:
             self._carriage.home()
-
-        elapsed = round(time.perf_counter() - start_time, 2)
-        return elapsed, max_time
 
     def _run_group(
         self,
@@ -145,15 +168,12 @@ class DispenserScheduler:
         is_cancelled: CancelCheck,
     ) -> None:
         """Run a group sequentially with carriage positioning before each item."""
-        if self._carriage is None:
-            raise ValueError("Carriage is required for this operation")
-        for item in group:
-            if is_cancelled():
-                break
-            self._carriage.move_to(item.dispenser.carriage_position)
+
+        def on_each(item: CarriageItem, _idx: int, _total: int) -> None:
+            assert isinstance(item, PreparationItem)
             self._run_exclusive(item, all_items, on_progress, is_cancelled)
-            if self._carriage.wait_after_dispense > 0 and not is_cancelled():
-                time.sleep(self._carriage.wait_after_dispense)
+
+        self._run_carriage_sequence(group, on_each=on_each, is_cancelled=is_cancelled)
 
     def _run_parallel(
         self,
@@ -164,12 +184,12 @@ class DispenserScheduler:
     ) -> None:
         """Run parallel dispensers with greedy scheduling (longest first, fill freed slots)."""
         queue = list(items)  # Already sorted by estimated_time desc
-        active: dict[Future[float], PreparationItem] = {}
+        active: dict[Future[None], PreparationItem] = {}
 
         with ThreadPoolExecutor(max_workers=self.max_concurrent) as executor:
             while queue and len(active) < self.max_concurrent:
                 data = queue.pop(0)
-                future = executor.submit(_run_dispenser, data)
+                future = executor.submit(_dispense_item, data)
                 active[future] = data
 
             while active:
@@ -187,11 +207,11 @@ class DispenserScheduler:
                     del active[f]
                     if queue:
                         next_data = queue.pop(0)
-                        new_future = executor.submit(_run_dispenser, next_data)
+                        new_future = executor.submit(_dispense_item, next_data)
                         active[new_future] = next_data
 
                 self._emit_progress(all_items, on_progress)
-                time.sleep(0.02)
+                time.sleep(_POLL_INTERVAL)
 
     def _run_exclusive(
         self,
@@ -203,23 +223,7 @@ class DispenserScheduler:
         """Run a single exclusive dispenser (blocking, no concurrency)."""
         if is_cancelled():
             return
-
-        def progress_callback(consumption_ml: float, is_done: bool) -> None:
-            item.consumption = consumption_ml
-            item.done = is_done
-            self._emit_progress(all_items, on_progress)
-
-        try:
-            consumption = item.dispenser.dispense(
-                amount_ml=item.amount_ml,
-                pump_speed=item.pump_speed,
-                revert=item.revert,
-                callback=progress_callback,
-            )
-            item.consumption = consumption
-            item.done = True
-        except Exception:
-            _logger.error(f"Exclusive dispenser error on slot {item.dispenser.slot}")
+        _dispense_item(item, on_step=lambda: self._emit_progress(all_items, on_progress))
 
     def _emit_progress(
         self,
@@ -228,11 +232,14 @@ class DispenserScheduler:
     ) -> None:
         total_required = sum(x.amount_ml for x in all_items)
         total_consumed = sum(x.consumption for x in all_items)
-        progress = min(int(total_consumed / total_required * 100), 100) if total_required > 0 else 0
+        progress = (
+            min(int(total_consumed / total_required * _PROGRESS_COMPLETE), _PROGRESS_COMPLETE)
+            if total_required > 0
+            else 0
+        )
         consumption = [x.consumption for x in all_items]
         on_progress(progress, consumption)
-        if self.verbose:
-            self._log_consumption(consumption, progress)
+        self._log_consumption(consumption, progress)
 
     def _log_consumption(self, consumption: list[float], progress: int) -> None:
         now = time.perf_counter()
@@ -243,23 +250,30 @@ class DispenserScheduler:
         _logger.debug(f"{progress:>2}% | Volumes: {pretty}")
 
 
-# TODO: this heavily overlaps with _run_exclusive ->> do we need _run_exclusive or can we merge this?
-def _run_dispenser(data: PreparationItem) -> float:
-    """Run a single dispenser. Called in a worker thread."""
+def _dispense_item(item: PreparationItem, on_step: Callable[[], None] | None = None) -> None:
+    """Run one dispenser; mutate item.consumption/done; log and swallow exceptions.
+
+    Shared by the parallel pool path (``on_step=None``; aggregate progress is
+    emitted by the outer polling loop) and the exclusive/carriage path
+    (``on_step`` emits aggregate progress on every consumption update).
+    """
 
     def callback(consumption_ml: float, is_done: bool) -> None:
-        data.consumption = consumption_ml
-        data.done = is_done
+        item.consumption = consumption_ml
+        item.done = is_done
+        if on_step is not None:
+            on_step()
 
-    consumption = data.dispenser.dispense(
-        amount_ml=data.amount_ml,
-        pump_speed=data.pump_speed,
-        revert=data.revert,
-        callback=callback,
-    )
-    data.consumption = consumption
-    data.done = True
-    return consumption
+    try:
+        item.consumption = item.dispenser.dispense(
+            amount_ml=item.amount_ml,
+            pump_speed=item.pump_speed,
+            revert=item.revert,
+            callback=callback,
+        )
+        item.done = True
+    except Exception as exc:
+        _logger.error(f"Dispenser error on slot {item.dispenser.slot}: {exc}")
 
 
 def _group_by_recipe_order(items: list[PreparationItem]) -> list[list[PreparationItem]]:
@@ -273,7 +287,7 @@ def _group_by_recipe_order(items: list[PreparationItem]) -> list[list[Preparatio
     return groups
 
 
-def _estimate_total_time(groups: list[list[PreparationItem]], max_concurrent: int) -> float:
+def estimate_total_time(groups: list[list[PreparationItem]], max_concurrent: int) -> float:
     """Estimate total preparation time across all recipe_order groups."""
     total = 0.0
     for group in groups:
@@ -298,7 +312,7 @@ def _estimate_group_time(estimated_times: list[float], max_concurrent: int) -> f
     return max(slots)
 
 
-def _estimate_carriage_time(
+def estimate_carriage_time(
     groups: list[list[PreparationItem]],
     carriage: CarriageInterface,
     home_position: int,
@@ -364,11 +378,8 @@ wall-clock duration, so the amount passed to dispense() must never be
 reached naturally.
 """
 
-_CLEANING_POLL_INTERVAL = 0.05
-"""How often (seconds) the cleaning loop checks elapsed time and cancellation."""
 
-
-class CleaningScheduler:
+class CleaningScheduler(BaseScheduler):
     """Schedules time-based pump cleaning.
 
     Each dispenser runs for a fixed wall-clock duration — no volume
@@ -376,14 +387,6 @@ class CleaningScheduler:
     processed in batches of up to *max_concurrent*. With a carriage,
     items run sequentially with position moves between each.
     """
-
-    def __init__(
-        self,
-        max_concurrent: int,
-        carriage: CarriageInterface | None = None,
-    ) -> None:
-        self.max_concurrent = max_concurrent
-        self._carriage = carriage
 
     def run(
         self,
@@ -395,7 +398,8 @@ class CleaningScheduler:
         if not items:
             return
         if self._carriage is not None:
-            self._run_with_carriage(items, on_progress, is_cancelled)
+            ordered = _order_by_carriage_position(items, self._carriage.home_position)
+            self._run_with_carriage(ordered, on_progress, is_cancelled)
             self._carriage.home()
         else:
             self._run_parallel(items, on_progress, is_cancelled)
@@ -412,30 +416,25 @@ class CleaningScheduler:
         for batch_idx, batch in enumerate(batches):
             if is_cancelled():
                 break
-            base = batch_idx * 100 // n_batches
-            ceiling = (batch_idx + 1) * 100 // n_batches
+            base = batch_idx * _PROGRESS_COMPLETE // n_batches
+            ceiling = (batch_idx + 1) * _PROGRESS_COMPLETE // n_batches
             self._run_timed(batch, on_progress, is_cancelled, base_progress=base, max_progress=ceiling)
 
     def _run_with_carriage(
         self,
-        items: list[CleaningItem],
+        ordered_items: Sequence[CleaningItem],
         on_progress: SchedulerProgressCallback,
         is_cancelled: CancelCheck,
     ) -> None:
         """Run items sequentially with carriage positioning before each."""
-        if self._carriage is None:
-            raise ValueError("Carriage is required for this operation")
-        ordered = _order_by_carriage_position(items, self._carriage.home_position)
-        total = len(ordered)
-        for idx, item in enumerate(ordered):
-            if is_cancelled():
-                break
-            self._carriage.move_to(item.dispenser.carriage_position)
-            base = idx * 100 // total
-            ceiling = (idx + 1) * 100 // total
+
+        def on_each(item: CarriageItem, idx: int, total: int) -> None:
+            assert isinstance(item, CleaningItem)
+            base = idx * _PROGRESS_COMPLETE // total
+            ceiling = (idx + 1) * _PROGRESS_COMPLETE // total
             self._run_timed([item], on_progress, is_cancelled, base_progress=base, max_progress=ceiling)
-            if self._carriage.wait_after_dispense > 0 and not is_cancelled():
-                time.sleep(self._carriage.wait_after_dispense)
+
+        self._run_carriage_sequence(ordered_items, on_each=on_each, is_cancelled=is_cancelled)
 
     def _run_timed(
         self,
@@ -453,7 +452,9 @@ class CleaningScheduler:
         duration = batch[0].duration_seconds
         with ThreadPoolExecutor(max_workers=len(batch)) as executor:
             futures = [
-                executor.submit(item.dispenser.dispense, _CLEANING_LARGE_AMOUNT, 100, item.revert, lambda *_: None)
+                executor.submit(
+                    item.dispenser.dispense, _CLEANING_LARGE_AMOUNT, _PROGRESS_COMPLETE, item.revert, lambda *_: None
+                )
                 for item in batch
             ]
             start = time.perf_counter()
@@ -465,9 +466,11 @@ class CleaningScheduler:
                     break
                 fraction = elapsed / duration
                 on_progress(base_progress + int(fraction * (max_progress - base_progress)), [])
-                time.sleep(_CLEANING_POLL_INTERVAL)
+                time.sleep(_POLL_INTERVAL)
             for f in futures:
-                with contextlib.suppress(Exception):
+                try:
                     f.result(timeout=2.0)
+                except Exception as exc:
+                    _logger.error(f"Cleaning dispenser error: {exc}")
         if not is_cancelled():
             on_progress(max_progress, [])

--- a/src/machine/dispensers/stepper.py
+++ b/src/machine/dispensers/stepper.py
@@ -5,7 +5,7 @@ from collections.abc import Generator
 from typing import TYPE_CHECKING
 
 from src.logger_handler import LoggerHandler
-from src.machine.dispensers.base import BaseDispenser
+from src.machine.dispensers.base import BaseDispenser, DispenseContext
 
 if TYPE_CHECKING:
     from src.config.config_types import StepperPumpConfig
@@ -48,6 +48,7 @@ class StepperDispenser(BaseDispenser):
         self.driver_type = config.driver_type
         self.step_type = config.step_type
         self._motor: rpi_motor_lib.A4988Nema | None = None
+        self._revert = False
         if not MOTOR_LIB_AVAILABLE:
             _logger.warning(f"RpiMotorLib not installed. Will not be able to control slot stepper slot {self.slot}")
             return
@@ -60,6 +61,12 @@ class StepperDispenser(BaseDispenser):
     @property
     def _log_label(self) -> str:
         return f"{self.driver_type:<14}"
+
+    def _before_dispense(self, ctx: DispenseContext) -> None:
+        self._revert = ctx.revert
+
+    def _after_dispense(self, ctx: DispenseContext) -> None:
+        self._revert = False
 
     def _dispense_steps(self, amount_ml: float, pump_speed: int) -> Generator[float]:
         flow_rate = self.volume_flow * pump_speed / 100
@@ -82,7 +89,7 @@ class StepperDispenser(BaseDispenser):
                 chunk = min(steps_per_chunk, total_steps - steps_done)
                 if self._motor is not None:
                     self._motor.motor_go(
-                        False,  # clockwise
+                        self._revert,  # clockwise; reversed when revert is active
                         self.step_type,
                         chunk,
                         step_delay,

--- a/src/machine/hardware.py
+++ b/src/machine/hardware.py
@@ -6,6 +6,7 @@ from typing import Any
 from src.machine.carriage import CarriageInterface
 from src.machine.leds import LedController
 from src.machine.pin_controller import PinController
+from src.machine.reverter import Reverter
 from src.machine.rfid import RFIDInterface
 from src.machine.scale import ScaleInterface
 
@@ -20,6 +21,7 @@ class HardwareContext:
 
     pin_controller: PinController
     led_controller: LedController
+    reverter: Reverter | None
     scale: ScaleInterface | None = field(default=None)
     carriage: CarriageInterface | None = field(default=None)
     rfid: RFIDInterface | None = field(default=None)
@@ -41,4 +43,6 @@ class HardwareContext:
             self.carriage.cleanup()
         if self.rfid is not None:
             self.rfid.cleanup()
+        if self.reverter is not None:
+            self.reverter.cleanup()
         self.pin_controller.cleanup_pin_list()

--- a/src/machine/reverter.py
+++ b/src/machine/reverter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from src.config.config_types import ReversionConfig
+from src.config.config_types import BaseReversionConfig, GlobalReversionConfig
 from src.logger_handler import LoggerHandler
 from src.machine.pin_controller import PinController
 
@@ -8,26 +8,35 @@ _logger = LoggerHandler("Reverter")
 
 
 class Reverter:
-    def __init__(self, config: ReversionConfig) -> None:
-        self._pin_controller = PinController()
-        # only init if reversion is enabled, otherwise it may be an invalid pin
-        self.use_reversion = config.use_reversion
+    def __init__(self, pin_controller: PinController, config: GlobalReversionConfig) -> None:
+        self._pin_controller = pin_controller
         self.revert_pin = config.pin_id
         self.inverted = config.inverted
 
     def initialize_pin(self) -> None:
-        if self.use_reversion:
-            _logger.info(f"<i> Initializing Reversion Pin: {self.revert_pin}")
-            self._pin_controller.initialize_pin(self.revert_pin, invert_override=self.inverted)
+        _logger.info(f"<i> Initializing Reversion Pin: {self.revert_pin}")
+        self._pin_controller.initialize_pin(self.revert_pin, invert_override=self.inverted)
 
     def revert_on(self) -> None:
         """Reverts the pump to be inverted."""
-        if not self.use_reversion:
-            return
         self._pin_controller.activate_pin(self.revert_pin)
 
     def revert_off(self) -> None:
         """Disables the reversion pin."""
-        if not self.use_reversion:
-            return
         self._pin_controller.close_pin(self.revert_pin)
+
+    def cleanup(self) -> None:
+        """Clean up the reversion pin."""
+        self._pin_controller.cleanup_pin(self.revert_pin)
+
+
+def create_reverter(config: BaseReversionConfig, pin_controller: PinController) -> Reverter | None:
+    """Create a Reverter from config, returning None when not active or not global.
+
+    Returns a Reverter only when the config is a GlobalReversionConfig with active=True.
+    DispenserControlledReversionConfig returns None because each dispenser
+    manages its own direction; nothing needs a shared reverter instance.
+    """
+    if not config.enabled or not isinstance(config, GlobalReversionConfig):
+        return None
+    return Reverter(pin_controller, config)

--- a/src/machine/scale/__init__.py
+++ b/src/machine/scale/__init__.py
@@ -39,7 +39,7 @@ def _health_check(scale: ScaleInterface) -> ScaleInterface | None:
     """
     ctx = multiprocessing.get_context("fork")
     queue: multiprocessing.Queue = ctx.Queue()  # type: ignore[type-arg]
-    proc = ctx.Process(target=_forked_read, args=(scale, queue), daemon=True)
+    proc = ctx.Process(target=_forked_read, args=(scale, queue), daemon=True)  # ty:ignore[unresolved-attribute]
     proc.start()
     proc.join(timeout=_SCALE_HEALTH_CHECK_TIMEOUT)
     if proc.is_alive():

--- a/src/migration/migrator.py
+++ b/src/migration/migrator.py
@@ -341,21 +341,32 @@ def _migrate_rfid_reader_to_discriminated_config() -> None:
 
 
 def _migrate_reversion_use_reversion_to_enabled() -> None:
-    """Rename ``use_reversion`` to ``enabled`` in ``MAKER_PUMP_REVERSION_CONFIG``.
+    """Migrate ``MAKER_PUMP_REVERSION_CONFIG`` to the discriminated shape.
+
+    - Renames ``use_reversion`` to ``enabled``
+    - Adds ``reversion_type: "Global"`` for legacy configs that only knew the global variant
 
     Old shape: ``MAKER_PUMP_REVERSION_CONFIG: {use_reversion: <bool>, ...}``
-    New shape: ``MAKER_PUMP_REVERSION_CONFIG: {enabled: <bool>, ...}``
+    New shape: ``MAKER_PUMP_REVERSION_CONFIG: {reversion_type: "Global", enabled: <bool>, ...}``
     """
     configuration = _get_local_config("MAKER_PUMP_REVERSION_CONFIG")
     if configuration is None:
         return
     reversion_config = configuration.get("MAKER_PUMP_REVERSION_CONFIG")
-    if not isinstance(reversion_config, dict) or "use_reversion" not in reversion_config:
+    if not isinstance(reversion_config, dict):
         return
-    reversion_config["enabled"] = reversion_config.pop("use_reversion")
+    changed = False
+    if "use_reversion" in reversion_config:
+        reversion_config["enabled"] = reversion_config.pop("use_reversion")
+        changed = True
+    if "reversion_type" not in reversion_config:
+        reversion_config["reversion_type"] = "Global"
+        changed = True
+    if not changed:
+        return
     with CUSTOM_CONFIG_FILE.open("w", encoding="UTF-8") as stream:
         yaml.dump(configuration, stream, default_flow_style=False)
-    _logger.info("Migrated MAKER_PUMP_REVERSION_CONFIG: use_reversion -> enabled")
+    _logger.info("Migrated MAKER_PUMP_REVERSION_CONFIG to discriminated shape")
 
 
 def _get_converted_value[T](new_type: Callable[[Any], T], default_value: T, local_config: Any) -> T:

--- a/src/migration/migrator.py
+++ b/src/migration/migrator.py
@@ -133,7 +133,10 @@ class Migrator:
                 _migrate_combine_led_lists_into_one_config,
                 migrate_waiter_privileges_to_roles,
             ],
-            "4.1.0": [add_disallow_pump_back_column_to_ingredients],
+            "4.1.0": [
+                add_disallow_pump_back_column_to_ingredients,
+                _migrate_reversion_use_reversion_to_enabled,
+            ],
         }
 
         for version, actions in version_actions.items():
@@ -335,6 +338,24 @@ def _migrate_rfid_reader_to_discriminated_config() -> None:
     with CUSTOM_CONFIG_FILE.open("w", encoding="UTF-8") as stream:
         yaml.dump(configuration, stream, default_flow_style=False)
     _logger.info(f"Migrated RFID_READER='{old_value}' to RFID_CONFIG")
+
+
+def _migrate_reversion_use_reversion_to_enabled() -> None:
+    """Rename ``use_reversion`` to ``enabled`` in ``MAKER_PUMP_REVERSION_CONFIG``.
+
+    Old shape: ``MAKER_PUMP_REVERSION_CONFIG: {use_reversion: <bool>, ...}``
+    New shape: ``MAKER_PUMP_REVERSION_CONFIG: {enabled: <bool>, ...}``
+    """
+    configuration = _get_local_config("MAKER_PUMP_REVERSION_CONFIG")
+    if configuration is None:
+        return
+    reversion_config = configuration.get("MAKER_PUMP_REVERSION_CONFIG")
+    if not isinstance(reversion_config, dict) or "use_reversion" not in reversion_config:
+        return
+    reversion_config["enabled"] = reversion_config.pop("use_reversion")
+    with CUSTOM_CONFIG_FILE.open("w", encoding="UTF-8") as stream:
+        yaml.dump(configuration, stream, default_flow_style=False)
+    _logger.info("Migrated MAKER_PUMP_REVERSION_CONFIG: use_reversion -> enabled")
 
 
 def _get_converted_value[T](new_type: Callable[[Any], T], default_value: T, local_config: Any) -> T:

--- a/src/skeletons/carriage_extension_skeleton.py
+++ b/src/skeletons/carriage_extension_skeleton.py
@@ -45,7 +45,7 @@ class ExtensionConfig(BaseCarriageConfig):
         enabled: bool = False,
         home_position: int = 0,
         speed_pct_per_s: float = 10.0,
-        move_during_cleaning: bool = False,
+        move_during_cleaning: bool = True,
         wait_after_dispense: float = 0.0,
         **kwargs: Any,
     ) -> None:

--- a/src/tabs/maker.py
+++ b/src/tabs/maker.py
@@ -170,7 +170,6 @@ def calibrate(bottle_number: int, amount: int, w: MainScreen | None = None) -> P
         ingredient_list=[ing],
         recipe=display_name,
         is_cocktail=False,
-        verbose=False,
     )
     return shared.cocktail_status.status
 

--- a/src/ui/setup_option_window.py
+++ b/src/ui/setup_option_window.py
@@ -167,7 +167,7 @@ class OptionWindow(QMainWindow, Ui_Optionwindow):
             return
         _logger.info("Cleaning requested over option UI, starting cleaning process")
         revert_pumps = False
-        if cfg.MAKER_PUMP_REVERSION_CONFIG.use_reversion:
+        if cfg.MAKER_PUMP_REVERSION_CONFIG.enabled:
             revert_pumps = DP_CONTROLLER.ask_to_use_reverted_pump()
         mc = MachineController()
         mc.clean_pumps(self.mainscreen, revert_pumps)

--- a/tests/test_machine_controller.py
+++ b/tests/test_machine_controller.py
@@ -171,8 +171,9 @@ class TestController:
         assert data.done is True
         mock_disp.dispense.assert_called_once()
         call_args = mock_disp.dispense.call_args
-        assert call_args[0][0] == 100  # amount_ml
-        assert call_args[0][1] == 100  # pump_speed
+        assert call_args.kwargs["amount_ml"] == 100
+        assert call_args.kwargs["pump_speed"] == 100
+        assert call_args.kwargs["revert"] is False
 
     @patch("src.machine.dispensers.scheduler.time.sleep")
     def test_scheduler_run(self, mock_sleep: MagicMock):
@@ -330,6 +331,7 @@ class TestCarriageScheduler:
         mock_carriage = MagicMock()
         mock_carriage.travel_time.return_value = 0.0
         mock_carriage.wait_after_dispense = 0.0
+        mock_carriage.home_position = 0
         mock_disp1 = _mock_dispenser(1, carriage_position=20)
         mock_disp2 = _mock_dispenser(2, carriage_position=60)
         mock_disp1.dispense.return_value = 10.0
@@ -342,7 +344,7 @@ class TestCarriageScheduler:
             PreparationItem(dispenser=mock_disp2, amount_ml=10, pump_speed=100, estimated_time=1.0, recipe_order=1),
         ]
 
-        scheduler = DispenserScheduler(max_concurrent=2, carriage=mock_carriage, home_position=0)
+        scheduler = DispenserScheduler(max_concurrent=2, carriage=mock_carriage)
         _current_time, max_time = scheduler.run(items, lambda p, c: None, lambda: False)
 
         # Sequential: 1.0 + 1.0 = 2.0
@@ -360,6 +362,7 @@ class TestCarriageScheduler:
         mock_carriage = MagicMock()
         mock_carriage.travel_time.return_value = 0.0
         mock_carriage.wait_after_dispense = 0.0
+        mock_carriage.home_position = 0
         mock_disp1 = _mock_dispenser(1, carriage_position=80)
         mock_disp2 = _mock_dispenser(2, carriage_position=20)
         mock_disp1.dispense.return_value = 10.0
@@ -372,7 +375,7 @@ class TestCarriageScheduler:
             PreparationItem(dispenser=mock_disp2, amount_ml=10, pump_speed=100, estimated_time=1.0, recipe_order=1),
         ]
 
-        scheduler = DispenserScheduler(max_concurrent=2, carriage=mock_carriage, home_position=0)
+        scheduler = DispenserScheduler(max_concurrent=2, carriage=mock_carriage)
         scheduler.run(items, lambda p, c: None, lambda: False)
 
         # Should move to position 20 first (closer to home=0), then 80

--- a/tests/test_machine_controller.py
+++ b/tests/test_machine_controller.py
@@ -7,14 +7,19 @@ from src.config.config_types import PumpConfig
 from src.machine.controller import MachineController
 from src.machine.dispensers.base import BaseDispenser
 from src.machine.dispensers.scheduler import (
+    _CLEANING_LARGE_AMOUNT,
+    BaseScheduler,
+    CleaningItem,
+    CleaningScheduler,
     DispenserScheduler,
     PreparationItem,
-    _estimate_carriage_time,
+    _dispense_item,
     _estimate_group_time,
     _group_by_recipe_order,
     _order_by_carriage_position,
-    _run_dispenser,
     _total_travel,
+    estimate_carriage_time,
+    estimate_total_time,
 )
 from src.models import Ingredient
 
@@ -153,7 +158,7 @@ class TestController:
         # Empty
         assert _estimate_group_time([], 2) == pytest.approx(0.0)
 
-    def test_run_dispenser(self):
+    def test_dispense_item(self):
         mock_disp = _mock_dispenser(1)
         mock_disp.dispense.return_value = 100.0
 
@@ -164,9 +169,8 @@ class TestController:
             estimated_time=10,
         )
 
-        result = _run_dispenser(data)
+        _dispense_item(data)
 
-        assert result == pytest.approx(100.0)
         assert data.consumption == pytest.approx(100.0)
         assert data.done is True
         mock_disp.dispense.assert_called_once()
@@ -174,6 +178,35 @@ class TestController:
         assert call_args.kwargs["amount_ml"] == 100
         assert call_args.kwargs["pump_speed"] == 100
         assert call_args.kwargs["revert"] is False
+
+    def test_dispense_item_calls_on_step(self):
+        """Exclusive path passes on_step to emit aggregate progress per update."""
+        mock_disp = _mock_dispenser(1)
+
+        def fake_dispense(amount_ml: float, pump_speed: int, revert: bool, callback) -> float:  # noqa: ANN001
+            callback(50.0, False)
+            callback(100.0, True)
+            return 100.0
+
+        mock_disp.dispense.side_effect = fake_dispense
+        data = PreparationItem(dispenser=mock_disp, amount_ml=100, pump_speed=100, estimated_time=10)
+        on_step = MagicMock()
+
+        _dispense_item(data, on_step=on_step)
+
+        assert on_step.call_count == 2
+        assert data.consumption == pytest.approx(100.0)
+        assert data.done is True
+
+    def test_dispense_item_swallows_exceptions(self):
+        mock_disp = _mock_dispenser(1)
+        mock_disp.dispense.side_effect = RuntimeError("boom")
+        data = PreparationItem(dispenser=mock_disp, amount_ml=100, pump_speed=100, estimated_time=10)
+
+        _dispense_item(data)  # must not raise
+
+        # consumption stays at default; done not set when an exception occurs
+        assert data.done is False
 
     @patch("src.machine.dispensers.scheduler.time.sleep")
     def test_scheduler_run(self, mock_sleep: MagicMock):
@@ -191,10 +224,11 @@ class TestController:
         ]
 
         scheduler = DispenserScheduler(max_concurrent=2)
-        _current_time, max_time = scheduler.run(items, lambda p, c: None, lambda: False)
+        scheduler.run(items, lambda p, c: None, lambda: False)
 
         # Verify max_time estimation: 1.0s + 1.0s for two sequential groups
-        assert max_time == pytest.approx(2.0)
+        groups = _group_by_recipe_order(items)
+        assert estimate_total_time(groups, 2) == pytest.approx(2.0)
         # Both dispensers should have been called
         mock_disp1.dispense.assert_called_once()
         mock_disp2.dispense.assert_called_once()
@@ -279,7 +313,7 @@ class TestCarriageOrdering:
         # home(0) -> 10 -> 50 -> 80 -> home(0) = 10 + 40 + 30 + 80 = 160
         assert _total_travel(items, home_position=0) == 160
 
-    def test_estimate_carriage_time(self):
+    def testestimate_carriage_time(self):
         mock_carriage = MagicMock()
         mock_carriage.travel_time.return_value = 0.0
         mock_carriage.wait_after_dispense = 0.0
@@ -296,9 +330,9 @@ class TestCarriageOrdering:
                 dispenser=_mock_dispenser(3), amount_ml=10, pump_speed=100, estimated_time=2.0, recipe_order=2
             ),
         ]
-        assert _estimate_carriage_time([items1, items2], mock_carriage, home_position=0) == pytest.approx(10.0)
+        assert estimate_carriage_time([items1, items2], mock_carriage, home_position=0) == pytest.approx(10.0)
 
-    def test_estimate_carriage_time_with_travel(self):
+    def testestimate_carriage_time_with_travel(self):
         mock_carriage = MagicMock()
         mock_carriage.wait_after_dispense = 0.0
         # travel_time returns |to - from| / 10 (simulating speed_pct_per_s=10)
@@ -320,7 +354,7 @@ class TestCarriageOrdering:
             ),
         ]
         # home(0)->20: 2.0s travel + 1.0s dispense + 20->60: 4.0s travel + 1.0s dispense + 60->0: 6.0s travel
-        result = _estimate_carriage_time([items], mock_carriage, home_position=0)
+        result = estimate_carriage_time([items], mock_carriage, home_position=0)
         assert result == pytest.approx(14.0)
 
 
@@ -345,10 +379,11 @@ class TestCarriageScheduler:
         ]
 
         scheduler = DispenserScheduler(max_concurrent=2, carriage=mock_carriage)
-        _current_time, max_time = scheduler.run(items, lambda p, c: None, lambda: False)
+        scheduler.run(items, lambda p, c: None, lambda: False)
 
         # Sequential: 1.0 + 1.0 = 2.0
-        assert max_time == pytest.approx(2.0)
+        groups = _group_by_recipe_order(items)
+        assert estimate_carriage_time(groups, mock_carriage, mock_carriage.home_position) == pytest.approx(2.0)
         # Carriage should move to each position then home
         assert mock_carriage.move_to.call_count == 2
         mock_carriage.home.assert_called_once()
@@ -398,9 +433,102 @@ class TestCarriageScheduler:
         ]
 
         scheduler = DispenserScheduler(max_concurrent=2)
-        _current_time, max_time = scheduler.run(items, lambda p, c: None, lambda: False)
+        scheduler.run(items, lambda p, c: None, lambda: False)
 
         # Parallel: max(1.0, 1.0) = 1.0
-        assert max_time == pytest.approx(1.0)
+        groups = _group_by_recipe_order(items)
+        assert estimate_total_time(groups, 2) == pytest.approx(1.0)
         mock_disp1.dispense.assert_called_once()
         mock_disp2.dispense.assert_called_once()
+
+
+class TestCleaningScheduler:
+    @patch("src.machine.dispensers.scheduler.time.sleep")
+    def test_cleaning_runs_each_dispenser(self, _mock_sleep: MagicMock):
+        """Each dispenser is invoked with the sentinel amount and stopped after duration."""
+        mock_disp1 = _mock_dispenser(1)
+        mock_disp2 = _mock_dispenser(2)
+        items = [
+            CleaningItem(dispenser=mock_disp1, duration_seconds=0.0),
+            CleaningItem(dispenser=mock_disp2, duration_seconds=0.0),
+        ]
+
+        CleaningScheduler(max_concurrent=2).run(items, lambda p, c: None, lambda: False)
+
+        mock_disp1.dispense.assert_called_once()
+        mock_disp2.dispense.assert_called_once()
+        # First positional arg passed to dispense is the sentinel amount.
+        assert mock_disp1.dispense.call_args.args[0] == _CLEANING_LARGE_AMOUNT
+        mock_disp1.stop.assert_called()
+        mock_disp2.stop.assert_called()
+
+    @patch("src.machine.dispensers.scheduler.time.sleep")
+    def test_cleaning_carriage_orders_by_position(self, _mock_sleep: MagicMock):
+        """Carriage cleaning reorders items by position to minimize travel."""
+        mock_carriage = MagicMock()
+        mock_carriage.wait_after_dispense = 0.0
+        mock_carriage.home_position = 0
+        mock_disp1 = _mock_dispenser(1, carriage_position=80)
+        mock_disp2 = _mock_dispenser(2, carriage_position=20)
+        items = [
+            CleaningItem(dispenser=mock_disp1, duration_seconds=0.0),
+            CleaningItem(dispenser=mock_disp2, duration_seconds=0.0),
+        ]
+
+        CleaningScheduler(max_concurrent=1, carriage=mock_carriage).run(items, lambda p, c: None, lambda: False)
+
+        move_calls = [call.args[0] for call in mock_carriage.move_to.call_args_list]
+        assert move_calls == [20, 80]
+        mock_carriage.home.assert_called_once()
+
+    @patch("src.machine.dispensers.scheduler.time.sleep")
+    def test_cleaning_progress_increases(self, _mock_sleep: MagicMock):
+        """Progress values are monotone non-decreasing and finish at 100."""
+        items = [
+            CleaningItem(dispenser=_mock_dispenser(1), duration_seconds=0.0),
+            CleaningItem(dispenser=_mock_dispenser(2), duration_seconds=0.0),
+        ]
+        seen: list[int] = []
+
+        CleaningScheduler(max_concurrent=1).run(items, lambda p, _c: seen.append(p), lambda: False)
+
+        assert seen, "progress should have been emitted at least once"
+        assert seen == sorted(seen)
+        assert seen[-1] == 100
+
+    @patch("src.machine.dispensers.scheduler.time.sleep")
+    def test_cleaning_cancellation_stops_dispensers(self, _mock_sleep: MagicMock):
+        """When is_cancelled returns True mid-run, stop() is called on the active batch."""
+        mock_disp1 = _mock_dispenser(1)
+        mock_disp2 = _mock_dispenser(2)
+        items = [
+            CleaningItem(dispenser=mock_disp1, duration_seconds=10.0),
+            CleaningItem(dispenser=mock_disp2, duration_seconds=10.0),
+        ]
+        # Cancel after the first poll so the timed loop exits and triggers stop.
+        cancel_calls = iter([False, True, True, True, True])
+        CleaningScheduler(max_concurrent=2).run(items, lambda p, c: None, lambda: next(cancel_calls, True))
+
+        mock_disp1.stop.assert_called()
+        mock_disp2.stop.assert_called()
+
+    @patch("src.machine.dispensers.scheduler.time.sleep")
+    def test_base_carriage_sequence_call_order(self, mock_sleep: MagicMock):
+        """BaseScheduler._run_carriage_sequence preserves move → on_each → sleep order."""
+        mock_carriage = MagicMock()
+        mock_carriage.wait_after_dispense = 0.5
+        mock_carriage.home_position = 0
+        disp = _mock_dispenser(1, carriage_position=30)
+        item = CleaningItem(dispenser=disp, duration_seconds=0.0)
+        scheduler = BaseScheduler(max_concurrent=1, carriage=mock_carriage)
+
+        events: list[str] = []
+        mock_carriage.move_to.side_effect = lambda *_: events.append("move")
+        mock_sleep.side_effect = lambda *_: events.append("sleep")
+
+        def on_each(_item: CleaningItem, _idx: int, _total: int) -> None:
+            events.append("on_each")
+
+        scheduler._run_carriage_sequence([item], on_each=on_each, is_cancelled=lambda: False)  # ty:ignore[invalid-argument-type]
+
+        assert events == ["move", "on_each", "sleep"]

--- a/tests/test_stepper_dispenser.py
+++ b/tests/test_stepper_dispenser.py
@@ -30,7 +30,7 @@ class TestStepperDispenser:
         d = self._make_dispenser()
         d._motor = MagicMock()
         callback = MagicMock()
-        consumption = d.dispense(10.0, 100, callback)
+        consumption = d.dispense(10.0, 100, False, callback)
         # Steps are based on duration / (2 * step_delay), not steps_per_ml
         total_steps_called = sum(call.args[2] for call in d._motor.motor_go.call_args_list)
         assert total_steps_called > 0
@@ -51,7 +51,7 @@ class TestStepperDispenser:
                 d._stop_event.set()
 
         callback.side_effect = stop_on_callback
-        consumption = d.dispense(10.0, 100, callback)
+        consumption = d.dispense(10.0, 100, False, callback)
         # Should have dispensed much less than the full 10ml
         assert consumption < 10.0
 
@@ -61,14 +61,14 @@ class TestStepperDispenser:
         callback = MagicMock()
 
         # Full speed - fewer steps (shorter duration)
-        d.dispense(1.0, 100, callback)
+        d.dispense(1.0, 100, False, callback)
         full_speed_steps = sum(call.args[2] for call in d._motor.motor_go.call_args_list)
 
         d._motor.reset_mock()
         callback.reset_mock()
 
         # Half speed - more steps (longer duration)
-        d.dispense(1.0, 50, callback)
+        d.dispense(1.0, 50, False, callback)
         half_speed_steps = sum(call.args[2] for call in d._motor.motor_go.call_args_list)
 
         # Half speed should take twice as long (double the steps at same step delay)

--- a/web_client/src/components/options/OptionWindow.tsx
+++ b/web_client/src/components/options/OptionWindow.tsx
@@ -58,7 +58,7 @@ const OptionWindow = () => {
 
   const cleanClick = async () => {
     const started = await confirmAndExecute(t('options.startCleaningProgram'), async () => {
-      const revertPumps = config.MAKER_PUMP_REVERSION_CONFIG?.use_reversion
+      const revertPumps = config.MAKER_PUMP_REVERSION_CONFIG?.enabled
         ? await askYesNo(t('options.useReversion'))
         : false;
       return cleanMachine(revertPumps);
@@ -146,7 +146,7 @@ const OptionWindow = () => {
             value={theme}
             allowedValues={Object.fromEntries(themes.map((t) => [t, t.charAt(0).toUpperCase() + t.slice(1)]))}
             handleInputChange={(value) => themeSelect(value)}
-            className='!p-2'
+            className='p-2!'
           />
         </div>
         <div className='grid gap-1 w-full grid-cols-1 md:grid-cols-2'>

--- a/web_client/src/types/models.ts
+++ b/web_client/src/types/models.ts
@@ -248,13 +248,24 @@ export interface CustomColors {
   danger: string;
 }
 
-export interface ReversionConfig {
-  use_reversion: boolean;
+export interface BaseReversionConfig {
+  reversion_type: 'Global' | 'Dispenser Controlled';
+  enabled: boolean;
+}
+
+export interface GlobalReversionConfig extends BaseReversionConfig {
+  reversion_type: 'Global';
   pin: number;
   pin_type: string;
   inverted: boolean;
   board_number: number;
 }
+
+export interface DispenserControlledReversionConfig extends BaseReversionConfig {
+  reversion_type: 'Dispenser Controlled';
+}
+
+export type ReversionConfig = GlobalReversionConfig | DispenserControlledReversionConfig;
 
 export interface I2CConfig {
   device_type: string;


### PR DESCRIPTION
This PR makes cleaning always time based instead of the usualy volume flow/weight based consumption calculation as the finish criteria. This way, all pumps can run in parallel (if no carriage is needed) and will have the right cleaning time, even if reversion is active.

Also add the option to revert on a per dispenser basis instead of globally. This additional introduce two customizable (default noop) hooks before and after dispensing start. Extension programmer can use some of this information (for example reversion requested) to additionally react on such cases.

closes #603, closes #604